### PR TITLE
Note how to fix the docker-compose issue on Fedora 25 system

### DIFF
--- a/docs/developing_running.md
+++ b/docs/developing_running.md
@@ -60,6 +60,14 @@ $ sudo docker-compose up
 
 To get the system up.
 
+If the following error message is displayed (Fedora 25 installation):
+`got an unexpected keyword argument 'user_agent'`
+you would need to upgrade the docker-py library by the following command:
+
+```
+$ sudo pip install --upgrade 'docker-py>=1.9.0'
+```
+
 If you want a good development setup (source code mounted inside the
 containers, ability to rebuild images using docker-compose), use:
 


### PR DESCRIPTION
On the clean Fedora 25 installation, the docker-compose command does not work. The proposed command installs new version of required library and fix this issue.