### PR TITLE
Use constant for services ports (to be used by tests lately)

### DIFF
--- a/integration-tests/features/environment.py
+++ b/integration-tests/features/environment.py
@@ -18,7 +18,6 @@ _API_ENDPOINT = 'api/v1/'
 # Ports used by various services
 _FABRIC8_ANALYTICS_SERVER = 32000
 _FABRIC8_ANALYTICS_JOBS = 34000
-_FABRIC8_MINIO_S3 = 33000
 
 
 def _make_compose_name(suffix='.yml'):

--- a/integration-tests/features/environment.py
+++ b/integration-tests/features/environment.py
@@ -15,6 +15,10 @@ _REPO_DIR = os.path.dirname(os.path.dirname(_THIS_DIR))
 # The following API endpoint is used to check if the system is started
 _API_ENDPOINT = 'api/v1/'
 
+# Ports used by various services
+_FABRIC8_ANALYTICS_SERVER = 32000
+_FABRIC8_ANALYTICS_JOBS = 34000
+_FABRIC8_MINIO_S3 = 33000
 
 
 def _make_compose_name(suffix='.yml'):
@@ -270,7 +274,7 @@ def before_all(context):
     
     context.coreapi_url = _add_slash(context.config.userdata.get(
         'coreapi_url',
-        'http://localhost:32000/'))
+        'http://localhost:' + str(_FABRIC8_ANALYTICS_SERVER) + '/'))
     context.anitya_url = _add_slash(context.config.userdata.get(
         'anitya_url',
         'http://localhost:31005/'))

--- a/integration-tests/features/environment.py
+++ b/integration-tests/features/environment.py
@@ -274,7 +274,7 @@ def before_all(context):
     
     context.coreapi_url = _add_slash(context.config.userdata.get(
         'coreapi_url',
-        'http://localhost:' + str(_FABRIC8_ANALYTICS_SERVER) + '/'))
+        'http://localhost:{port}/'.format(port=_FABRIC8_ANALYTICS_SERVER)))
     context.anitya_url = _add_slash(context.config.userdata.get(
         'anitya_url',
         'http://localhost:31005/'))


### PR DESCRIPTION
As we are starting to make tests for various services, let's refactor theirs port numbers.