### PR TITLE
Initial number of jobs

### DIFF
--- a/integration-tests/features/jobs_api.feature
+++ b/integration-tests/features/jobs_api.feature
@@ -25,3 +25,9 @@ Feature: Jobs API
     Then I should receive JSON response containing the jobs key
     Then I should receive JSON response containing the jobs_count key
 
+  Scenario: Check initial number of jobs
+    Given System is running
+    When I access jobs API /api/v1/jobs
+    Then I should get 200 status code
+    Then I should see 4 jobs
+

--- a/integration-tests/features/steps/common.py
+++ b/integration-tests/features/steps/common.py
@@ -137,6 +137,15 @@ def check_ecosystems(context, num):
         assert 'ecosystem' in e
 
 
+@then('I should see {num:d} jobs')
+def check_jobs(context, num):
+    jsondata = context.response.json()
+    jobs = jsondata['jobs']
+    jobs_count = jsondata['jobs_count']
+    assert len(jobs) == num
+    assert jobs_count == num
+
+
 @then('I should see 0 packages')
 @then('I should see {num:d} packages ({packages}), all from {ecosystem} ecosystem')
 def check_packages(context, num=0, packages='', ecosystem=''):


### PR DESCRIPTION
Another simple test case - check the initial number of jobs in the system. The next step would be to insert new job, check if it is in the system etc. (according to existing API scheme)