### PR TITLE
Use GitHub service to display HTML page

### DIFF
--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -46,11 +46,11 @@ features executed by the [runtest.sh](runtest.sh) script.
 ### Currently defined test steps
 
 Documentation for the module with test steps is automatically generated into
-the file [common.html]. The available test steps are not currently documented
-yet, so refer to either the existing scenario definitions for usage examples,
-or else the step definitions in
-[features/steps/common.py](features/steps/common.py) and the adjacent step
-files.
+the file [common.html](http://htmlpreview.github.io/?https://github.com/fabric8-analytics/fabric8-analytics-common/blob/master/integration-tests/common.html).
+The available test steps are not currently documented yet, so refer to either
+the existing scenario definitions for usage examples, or else the step
+definitions in [features/steps/common.py](features/steps/common.py) and the
+adjacent step files.
 
 ### Adding new test step files
 


### PR DESCRIPTION
Actually the HTML page can't be directly displayable via normal link, so I'd suggest to use GitHub service to do it (RFE - use other output format, preferably Markdown)