### PR TITLE
New entrypoint to check in smoke test

### DIFF
--- a/integration-tests/features/smoketest.feature
+++ b/integration-tests/features/smoketest.feature
@@ -22,6 +22,11 @@ Feature: Smoke test
 
   Scenario: Check the jobs API entry point
     Given System is running
+    When I access jobs API /api/v1
+    Then I should get 200 status code
+
+  Scenario: Check the jobs API entry point
+    Given System is running
     When I access jobs API /api/v1/readiness
     Then I should get 200 status code
 


### PR DESCRIPTION
Now the /api/v1 entrypoint is implemented for the jobs service, so we can check it. Here's the 1st step - smoketest ;)