### PR TITLE
[docker-compose.yml] define NUMBER_WORKER_PROCESS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -273,6 +273,7 @@ services:
     environment:
       DATA_IMPORTER_SERVICE_PORT: "9192"
       DATA_IMPORTER_SERVICE_TIMEOUT: "3600"
+      NUMBER_WORKER_PROCESS: "1"
       # controls whether to use http/ws or https/wss
       GREMLIN_USE_SECURE_CONNECTION: "false"
       BAYESIAN_GREMLIN_HTTP_SERVICE_HOST: "bayesian-gremlin-http"


### PR DESCRIPTION
it's used in [entrypoint.sh](https://github.com/fabric8-analytics/fabric8-analytics-data-model/blob/master/scripts/entrypoint.sh)

fixes:
`data-model-importer_1 | gunicorn: error: argument -w/--workers: invalid int value: 'rest_api:app'`

