### PR TITLE
Check analyzed dependencies

### DIFF
--- a/integration-tests/features/stack_analyses_v2.feature
+++ b/integration-tests/features/stack_analyses_v2.feature
@@ -29,3 +29,34 @@ Feature: Stack analysis v2 API
     When I wait for stack analysis version 2 to finish
     Then I should get 200 status code
 
+  Scenario: Check the analyzed dependencies for newer version of click package
+    When I send Python package manifest requirements_click_newest_6_7.txt to stack analysis version 2
+    Then I should get 200 status code
+    When I wait for stack analysis version 2 to finish
+    Then I should get 200 status code
+    Then I should find the value click under the path result/0/user_stack_info/analyzed_dependencies/0/package in the JSON response
+    Then I should find the value 6.7 under the path result/0/user_stack_info/analyzed_dependencies/0/version in the JSON response
+
+  Scenario: Check the analyzed dependencies for older version of click package
+    When I send Python package manifest requirements_click_version_eq_5_0.txt to stack analysis version 2
+    Then I should get 200 status code
+    When I wait for stack analysis version 2 to finish
+    Then I should get 200 status code
+    Then I should find the value click under the path result/0/user_stack_info/analyzed_dependencies/0/package in the JSON response
+    Then I should find the value 5.0 under the path result/0/user_stack_info/analyzed_dependencies/0/version in the JSON response
+
+  Scenario: Check the analyzed dependencies for older version of click package with click>=5.0 in requirements
+    When I send Python package manifest requirements_click_version_ge_5_0.txt to stack analysis version 2
+    Then I should get 200 status code
+    When I wait for stack analysis version 2 to finish
+    Then I should get 200 status code
+    Then I should find the value click under the path result/0/user_stack_info/analyzed_dependencies/0/package in the JSON response
+    Then I should find the value 6.7 under the path result/0/user_stack_info/analyzed_dependencies/0/version in the JSON response
+
+  Scenario: Check the analyzed dependencies for older version of click package with click>5.0 in requirements
+    When I send Python package manifest requirements_click_version_gt_5_0.txt to stack analysis version 2
+    Then I should get 200 status code
+    When I wait for stack analysis version 2 to finish
+    Then I should get 200 status code
+    Then I should find the value click under the path result/0/user_stack_info/analyzed_dependencies/0/package in the JSON response
+    Then I should find the value 6.7 under the path result/0/user_stack_info/analyzed_dependencies/0/version in the JSON response


### PR DESCRIPTION
Basic checks if package versions are handled properly, even if the requirements.txt contains clauses like >, >=, <= etc.