### PR TITLE
Check analyzed dependency

### DIFF
--- a/integration-tests/features/steps/common.py
+++ b/integration-tests/features/steps/common.py
@@ -642,3 +642,19 @@ def check_stack_analysis_id(context):
     assert previous_id is not None
     assert request_id is not None
     assert previous_id == request_id
+
+
+@then('I should find analyzed dependency named {package} with version {version} in the stack analysis')
+def check_analyzed_dependency(context, package, version):
+    jsondata = context.response.json()
+    assert jsondata is not None
+    path = "result/0/user_stack_info/analyzed_dependencies"
+    analyzed_dependencies = get_value_using_path(jsondata, path)
+    assert analyzed_dependencies is not None
+    for analyzed_dependency in analyzed_dependencies:
+        if analyzed_dependency["package"] == package \
+           and analyzed_dependency["version"] == version:
+            break
+    else:
+        raise Exception('Package {package} with version {version} not found'.
+                        format(package=package, version=version))


### PR DESCRIPTION
It seems we will need to test analyzed dependencies very frequently so I think it would be good to be able to define following checks:

```
Then I should find analyzed dependency named click with version 6.7 in the stack analysis
```