### PR TITLE
Updated requirements.txt + added note howto install pip-compile

### DIFF
--- a/integration-tests/requirements.txt
+++ b/integration-tests/requirements.txt
@@ -4,14 +4,19 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
+# To install pip-compile, run:
+#    pip install pip-tools
+#
 behave==1.2.5
 docker-py==1.10.6
 docker-pycreds==0.2.1     # via docker-py
+enum34==1.1.6             # via parse-type
 jsonschema==2.5.1
 parse-type==0.3.4         # via behave
 parse==1.6.6              # via behave, parse-type
 py==1.4.31                # via pytest
 pytest==3.0.3
+repoze.lru==0.6           # via jsonschema
 requests==2.11.1
 six==1.10.0               # via behave, docker-py, docker-pycreds, parse-type, websocket-client
 websocket-client==0.37.0  # via docker-py


### PR DESCRIPTION
Just and update of requirements.txt used by integration tests. I've also added note howto install pip-compile (it is not obvious for Python apprentices ;)