### PR TITLE
Integration tests specific settings

### DIFF
--- a/docker-compose.integration-tests.yml
+++ b/docker-compose.integration-tests.yml
@@ -1,0 +1,5 @@
+version: "2"
+services:
+  server:
+    environment:
+      DISABLE_AUTHENTICATION: 0

--- a/integration-tests/features/environment.py
+++ b/integration-tests/features/environment.py
@@ -30,8 +30,9 @@ def _make_compose_name(suffix='.yml'):
 
 def _set_default_compose_path(context):
     base_compose = _make_compose_name()
+    test_specific_compose = _make_compose_name(".integration-tests.yml")
     # Extra containers are added as needed by integration setup commands
-    context.docker_compose_path = [base_compose]
+    context.docker_compose_path = [base_compose, test_specific_compose]
 
 ### make sure behave uses pytest improved asserts
 # Behave runner uses behave.runner.exec_file function to read, compile


### PR DESCRIPTION
The settings for integration tests might be different that settings that devels want to use. This particular change make sure that authentication module is not disabled during testing.