### PR TITLE
Download stack analysis threshold value

### DIFF
--- a/integration-tests/features/stack_analyses_v2.feature
+++ b/integration-tests/features/stack_analyses_v2.feature
@@ -1,5 +1,9 @@
 Feature: Stack analysis v2 API
 
+  Scenario: Read outlier probability threshold value
+    When I download and parse outlier probability threshold value
+    Then I should have outlier probability threshold value between 0.0 and 1.0
+
   Scenario: Check that the API entry point
     Given System is running
     When I access /api/v1/stack-analyses-v2

--- a/integration-tests/features/steps/common.py
+++ b/integration-tests/features/steps/common.py
@@ -744,3 +744,40 @@ def generate_authorization_token(context, private_key):
 @then('I should get the proper authorization token')
 def is_proper_authorization_token(context):
     assert context.token is not None
+
+
+def download_file_from_url(url):
+    """Download file from the given URL and do basic check of response."""
+    response = requests.get(url)
+    assert response.status_code == 200
+    assert response.text is not None
+    return response.text
+
+
+def parse_float_value_from_text_stream(text, key):
+    """Go through all lines of the text file, find the line with given key
+    and parse float value specified here"""
+    regexp = key + "\s*=\s*(\d.\d*)"
+    for line in text.split("\n"):
+        if line.startswith(key):
+            match = re.match(regexp, line)
+            assert match is not None
+            assert match.lastindex == 1
+            return float(match.group(1))
+
+
+@when('I download and parse outlier probability threshold value')
+def download_and_parse_outlier_probability_threshold_value(context):
+    """Special step that is needed to get the stack analysis outlier
+    probability threshold."""
+    content = download_file_from_url(STACK_ANALYSIS_CONSTANT_FILE_URL)
+    context.outlier_probability_threshold = parse_float_value_from_text_stream(
+        content, STACK_ANALYSIS_OUTLIER_PROBABILITY_CONSTANT_NAME)
+
+
+@then('I should have outlier probability threshold value between {min:f} and {max:f}')
+def check_outlier_probability_threshold_value(context, min, max):
+    v = context.outlier_probability_threshold
+    assert v is not None
+    assert v >= min
+    assert v <= max

--- a/integration-tests/features/steps/common.py
+++ b/integration-tests/features/steps/common.py
@@ -769,7 +769,7 @@ def parse_float_value_from_text_stream(text, key):
     regexp = key + "\s*=\s*(\d.\d*)"
     for line in text.split("\n"):
         if line.startswith(key):
-            match = re.match(regexp, line)
+            match = re.fullmatch(regexp, line)
             assert match is not None
             assert match.lastindex == 1
             return float(match.group(1))

--- a/integration-tests/features/steps/common.py
+++ b/integration-tests/features/steps/common.py
@@ -3,6 +3,7 @@ import datetime
 import json
 import time
 import os
+import re
 
 from behave import given, then, when
 from urllib.parse import urljoin
@@ -12,6 +13,14 @@ import requests
 import jwt
 import base64
 from jwt.contrib.algorithms.pycrypto import RSAAlgorithm
+
+
+STACK_ANALYSIS_CONSTANT_FILE_URL = "https://raw.githubusercontent.com/" \
+"fabric8-analytics/fabric8-analytics-stack-analysis/master/" \
+"analytics_platform/kronos/pgm/src/pgm_constants.py"
+
+STACK_ANALYSIS_OUTLIER_PROBABILITY_CONSTANT_NAME = \
+    "KRONOS_OUTLIER_PROBABILITY_THRESHOLD_VALUE"
 
 
 jwt.register_algorithm('RS256', RSAAlgorithm(RSAAlgorithm.SHA256))


### PR DESCRIPTION
Special step that is needed to get the stack analysis outlier probability threshold. That value is to be used in ongoing stack analysis v2 tests, and we don't want to use fixed magic constant in such tests.