### PR TITLE
Allow waiting for the service with authorization

### DIFF
--- a/integration-tests/features/environment.py
+++ b/integration-tests/features/environment.py
@@ -234,7 +234,7 @@ def _restart_system(context, wait_for_server=60):
 def _is_api_running(url):
     try:
         res = requests.get(url)
-        if res.status_code == 200:
+        if res.status_code in {200, 401}:
             return True
     except requests.exceptions.ConnectionError:
         pass


### PR DESCRIPTION
Check for the component service availability should check the 401 code as well when auth is enabled.