### PR TITLE
[docker-compose.yml] define SCANCODE_PROCESSES to speed up license scans

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -193,6 +193,7 @@ services:
       GCP_TOKEN_URI: ""
       GCP_AUTH_PROVIDER_X509_CERT_URL: ""
       GCP_CLIENT_X509_CERT_URL: ""
+      SCANCODE_PROCESSES: "4"
     tty: true  # yes, really -ti -d, binwalk chokes when there's no tty kept open
   worker-ingestion:
     <<: *worker


### PR DESCRIPTION
Follow-up of https://github.com/fabric8-analytics/fabric8-analytics-worker/pull/183