### PR TITLE
Auth method for jobs api

### DIFF
--- a/integration-tests/features/steps/common.py
+++ b/integration-tests/features/steps/common.py
@@ -852,6 +852,11 @@ def is_proper_authorization_token(context):
     assert context.token is not None
 
 
+@then('I should get the proper job API authorization token')
+def is_proper_authorization_token(context):
+    assert context.jobs_api_token is not None
+
+
 @when('I acquire the authorization token')
 def acquire_authorization_token(context):
     recommender_token = os.environ.get("RECOMMENDER_API_TOKEN")
@@ -860,6 +865,12 @@ def acquire_authorization_token(context):
         context.token = recommender_token
     else:
         generate_authorization_token(context, DEFAULT_AUTHORIZATION_TOKEN_FILENAME)
+
+
+@when('I acquire job API authorization token')
+def acquire_jobs_api_authorization_token(context):
+    context.jobs_api_token = os.environ.get("JOB_API_TOKEN")
+    # TODO: authorization via GitHub?
 
 
 def download_file_from_url(url):

--- a/integration-tests/features/steps/common.py
+++ b/integration-tests/features/steps/common.py
@@ -94,6 +94,10 @@ def perform_kerberized_request(context, method, url):
                                           command)
 
 
+def jobs_api_authorization(context):
+    return {'auth-token': '{token}'.format(token=context.jobs_api_token)}
+
+
 def authorization(context):
     return {'Authorization': 'Bearer {token}'.format(token=context.token)}
 
@@ -248,7 +252,7 @@ def jobs_api_url(context, url):
 def jobs_api_url_with_authorization_token(context, url):
     """Access the jobs service API using the HTTP GET method."""
     context.response = requests.get(context.jobs_api_url + url,
-                                    headers=authorization(context))
+                                    headers=jobs_api_authorization(context))
 
 
 @when('I access {url:S}')


### PR DESCRIPTION
The 1st step to resolve #208 - if there's environment variable with the job API token, use it.

Usage:

```
  Scenario: Check initial number of jobs
    Given System is running
    When I acquire job API authorization token
    Then I should get the proper job API authorization token
    When I access jobs API /api/v1/jobs with authorization token
    Then I should get 200 status code
    Then I should see 4 jobs
```