### PR TITLE
Unique job ids + use authorization + test fixes

### DIFF
--- a/integration-tests/features/jobs_api.feature
+++ b/integration-tests/features/jobs_api.feature
@@ -224,6 +224,7 @@ Feature: Jobs API
     Then I should get 200 status code
     Then I should receive JSON response with the state key set to running
 
+  @jobs.requires_auth
   Scenario: Check if improper job service state is detected properly
     Given System is running
     When I acquire job API authorization token
@@ -231,6 +232,7 @@ Feature: Jobs API
     When I set status for job service to UNKNOWN
     Then I should get 400 status code
 
+  @jobs.requires_auth
   Scenario: Check if new job service state is checked
     Given System is running
     When I acquire job API authorization token

--- a/integration-tests/features/jobs_api.feature
+++ b/integration-tests/features/jobs_api.feature
@@ -141,7 +141,7 @@ Feature: Jobs API
     Given System is running
     When I acquire job API authorization token
     Then I should get the proper job API authorization token
-    When I delete job without ID
+    When I delete job without ID using authorization token
     Then I should get 405 status code
 
   @jobs.requires_auth

--- a/integration-tests/features/jobs_api.feature
+++ b/integration-tests/features/jobs_api.feature
@@ -69,33 +69,42 @@ Feature: Jobs API
   @jobs.requires_auth
   Scenario: Check that job with given ID can be posted via API
     Given System is running
-    When I post a job metadata job1.json with job id TEST_1 and state paused
+    When I acquire job API authorization token
+    Then I should get the proper job API authorization token
+    When I generate unique job ID prefix
+    When I post a job metadata job1.json with job id TEST_1 and state paused using authorization token
     Then I should get 201 status code
 
   @jobs.requires_auth
   Scenario: Check that job with given ID is really registered
     Given System is running
-    When I post a job metadata job1.json with job id TEST_2 and state paused
+    When I acquire job API authorization token
+    Then I should get the proper job API authorization token
+    When I generate unique job ID prefix
+    When I post a job metadata job1.json with job id TEST_2 and state paused using authorization token
     Then I should get 201 status code
-    When I access jobs API /api/v1/jobs
+    When I access jobs API /api/v1/jobs with authorization token
     Then I should find job with id TEST_2
 
   @jobs.requires_auth
   Scenario: Check that jobs are not replaced
     Given System is running
-    When I access jobs API /api/v1/jobs
+    When I acquire job API authorization token
+    Then I should get the proper job API authorization token
+    When I generate unique job ID prefix
+    When I access jobs API /api/v1/jobs with authorization token
     Then I should not find job with id TEST_3
     Then I should not find job with id TEST_4
     Then I should not find job with id TEST_5
-    When I post a job metadata job1.json with job id TEST_3 and state paused
+    When I post a job metadata job1.json with job id TEST_3 and state paused using authorization token
     Then I should get 201 status code
-    When I access jobs API /api/v1/jobs
+    When I access jobs API /api/v1/jobs with authorization token
     Then I should find job with id TEST_3
     Then I should not find job with id TEST_4
     Then I should not find job with id TEST_5
-    When I post a job metadata job1.json with job id TEST_4 and state paused
+    When I post a job metadata job1.json with job id TEST_4 and state paused using authorization token
     Then I should get 201 status code
-    When I access jobs API /api/v1/jobs
+    When I access jobs API /api/v1/jobs with authorization token
     Then I should find job with id TEST_3
     Then I should find job with id TEST_4
     Then I should not find job with id TEST_5
@@ -103,37 +112,46 @@ Feature: Jobs API
   @jobs.requires_auth
   Scenario: Check that jobs can be deleted
     Given System is running
-    When I access jobs API /api/v1/jobs
+    When I acquire job API authorization token
+    When I generate unique job ID prefix
+    Then I should get the proper job API authorization token
+    When I access jobs API /api/v1/jobs with authorization token
     Then I should not find job with id TEST_TO_DELETE
-    When I post a job metadata job1.json with job id TEST_TO_DELETE and state paused
+    When I post a job metadata job1.json with job id TEST_TO_DELETE and state paused using authorization token
     Then I should get 201 status code
-    When I access jobs API /api/v1/jobs
+    When I access jobs API /api/v1/jobs with authorization token
     Then I should find job with id TEST_TO_DELETE
-    When I delete job with id TEST_TO_DELETE
+    When I delete job with id TEST_TO_DELETE using authorization token
     Then I should get 200 status code
-    When I access jobs API /api/v1/jobs
+    When I access jobs API /api/v1/jobs with authorization token
     Then I should not find job with id TEST_TO_DELETE
 
   @jobs.requires_auth
   Scenario: Check that nonexistent job can't be deleted
     Given System is running
-    When I access jobs API /api/v1/jobs
+    When I acquire job API authorization token
+    Then I should get the proper job API authorization token
+    When I access jobs API /api/v1/jobs with authorization token
     Then I should not find job with id NONEXISTENT_JOB
-    When I delete job with id NONEXISTENT_JOB
+    When I delete job with id NONEXISTENT_JOB using authorization token
     Then I should get 410 status code
 
   @jobs.requires_auth
   Scenario: Check that job w/o ID can't be deleted
     Given System is running
+    When I acquire job API authorization token
+    Then I should get the proper job API authorization token
     When I delete job without ID
     Then I should get 405 status code
 
   @jobs.requires_auth
   Scenario: Check that job status can be changed
     Given System is running
+    When I acquire job API authorization token
+    Then I should get the proper job API authorization token
     When I post a job metadata job1.json with job id PAUSED_JOB and state paused
     Then I should get 201 status code
-    When I access jobs API /api/v1/jobs
+    When I access jobs API /api/v1/jobs with authorization token
     Then I should find job with id PAUSED_JOB
     Then I should find job with id PAUSED_JOB and state paused
     When I set status for job with id PAUSED_JOB to paused
@@ -144,9 +162,11 @@ Feature: Jobs API
   @jobs.requires_auth
   Scenario: Check wrong status behaviour
     Given System is running
+    When I acquire job API authorization token
+    Then I should get the proper job API authorization token
     When I post a job metadata job1.json with job id PAUSED_JOB_2 and state paused
     Then I should get 201 status code
-    When I access jobs API /api/v1/jobs
+    When I access jobs API /api/v1/jobs with authorization token
     Then I should find job with id PAUSED_JOB_2 and state paused
     When I set status for job with id PAUSED_JOB_2 to unknown_state
     Then I should get 400 status code
@@ -154,12 +174,16 @@ Feature: Jobs API
   @jobs.requires_auth
   Scenario: Check setting status for wrong job behaviour
     Given System is running
+    When I acquire job API authorization token
+    Then I should get the proper job API authorization token
     When I set status for job with id NONEXISTENT_JOB to paused
     Then I should get 404 status code
 
   @jobs.requires_auth
   Scenario: Check job service state manipulation
     Given System is running
+    When I acquire job API authorization token
+    Then I should get the proper job API authorization token
     When I access jobs API /api/v1/service/state
     Then I should get 200 status code
     Then I should receive JSON response with the state key set to running
@@ -177,6 +201,8 @@ Feature: Jobs API
   @jobs.requires_auth
   Scenario: Check job service state set to the same value
     Given System is running
+    When I acquire job API authorization token
+    Then I should get the proper job API authorization token
     When I set status for job service to paused
     Then I should get 200 status code
     When I access jobs API /api/v1/service/state
@@ -200,17 +226,23 @@ Feature: Jobs API
 
   Scenario: Check if improper job service state is detected properly
     Given System is running
+    When I acquire job API authorization token
+    Then I should get the proper job API authorization token
     When I set status for job service to UNKNOWN
     Then I should get 400 status code
 
   Scenario: Check if new job service state is checked
     Given System is running
+    When I acquire job API authorization token
+    Then I should get the proper job API authorization token
     When I reset status for the job service
     Then I should get 400 status code
 
   @jobs.requires_auth
   Scenario: Check the API call to clean all failed jobs
     Given System is running
+    When I acquire job API authorization token
+    Then I should get the proper job API authorization token
     When I clean all failed jobs
     Then I should get 200 status code
 

--- a/integration-tests/features/jobs_api.feature
+++ b/integration-tests/features/jobs_api.feature
@@ -203,24 +203,24 @@ Feature: Jobs API
     Given System is running
     When I acquire job API authorization token
     Then I should get the proper job API authorization token
-    When I set status for job service to paused
+    When I set status for job service to paused using authorization token
     Then I should get 200 status code
-    When I access jobs API /api/v1/service/state
-    Then I should get 200 status code
-    Then I should receive JSON response with the state key set to paused
-    When I set status for job service to paused
-    Then I should get 200 status code
-    When I access jobs API /api/v1/service/state
+    When I access jobs API /api/v1/service/state with authorization token
     Then I should get 200 status code
     Then I should receive JSON response with the state key set to paused
-    When I set status for job service to running
+    When I set status for job service to paused using authorization token
     Then I should get 200 status code
-    When I access jobs API /api/v1/service/state
+    When I access jobs API /api/v1/service/state with authorization token
+    Then I should get 200 status code
+    Then I should receive JSON response with the state key set to paused
+    When I set status for job service to running using authorization token
+    Then I should get 200 status code
+    When I access jobs API /api/v1/service/state with authorization token
     Then I should get 200 status code
     Then I should receive JSON response with the state key set to running
-    When I set status for job service to running
+    When I set status for job service to running using authorization token
     Then I should get 200 status code
-    When I access jobs API /api/v1/service/state
+    When I access jobs API /api/v1/service/state with authorization token
     Then I should get 200 status code
     Then I should receive JSON response with the state key set to running
 
@@ -243,6 +243,6 @@ Feature: Jobs API
     Given System is running
     When I acquire job API authorization token
     Then I should get the proper job API authorization token
-    When I clean all failed jobs
+    When I clean all failed jobs with authorization token
     Then I should get 200 status code
 

--- a/integration-tests/features/jobs_api.feature
+++ b/integration-tests/features/jobs_api.feature
@@ -184,17 +184,17 @@ Feature: Jobs API
     Given System is running
     When I acquire job API authorization token
     Then I should get the proper job API authorization token
-    When I access jobs API /api/v1/service/state
+    When I access jobs API /api/v1/service/state with authorization token
     Then I should get 200 status code
     Then I should receive JSON response with the state key set to running
-    When I set status for job service to paused
+    When I set status for job service to paused using authorization token
     Then I should get 200 status code
-    When I access jobs API /api/v1/service/state
+    When I access jobs API /api/v1/service/state with authorization token
     Then I should get 200 status code
     Then I should receive JSON response with the state key set to paused
-    When I set status for job service to running
+    When I set status for job service to running using authorization token
     Then I should get 200 status code
-    When I access jobs API /api/v1/service/state
+    When I access jobs API /api/v1/service/state with authorization token
     Then I should get 200 status code
     Then I should receive JSON response with the state key set to running
 

--- a/integration-tests/features/steps/common.py
+++ b/integration-tests/features/steps/common.py
@@ -459,13 +459,18 @@ def set_job_status(context, job_id, status):
 
 @when("I reset status for the job service")
 @when("I set status for job service to {status}")
-def set_job_service_status(context, status=None):
+@when("I set status for job service to {status} {token} authorization token")
+def set_job_service_status(context, status=None, token="without"):
     """API call to set or reset job service status."""
     url = "{jobs_api_url}api/v1/service/state".format(
             jobs_api_url=context.jobs_api_url)
+    use_token = parse_token_clause(token)
     if status is not None:
         url = "{url}?state={status}".format(url=url, status=status)
-    context.response = requests.put(url)
+    if use_token:
+        context.response = requests.put(url, headers=jobs_api_authorization(context))
+    else:
+        context.response = requests.put(url)
 
 
 @when("I clean all failed jobs")

--- a/integration-tests/features/steps/common.py
+++ b/integration-tests/features/steps/common.py
@@ -9,6 +9,7 @@ from behave import given, then, when
 from urllib.parse import urljoin
 import jsonschema
 import requests
+import uuid
 
 import jwt
 from jwt.contrib.algorithms.pycrypto import RSAAlgorithm
@@ -1337,6 +1338,11 @@ def check_security_issue_existence(context, cve, package):
     else:
         raise Exception('Could not find the analyzed package {p}'
                         .format(p=package))
+
+
+@when('I generate unique job ID prefix')
+def generate_job_id_prefix(context):
+    context.job_id_prefix = uuid.uuid1()
 
 
 class MockedResponse():

--- a/integration-tests/features/steps/common.py
+++ b/integration-tests/features/steps/common.py
@@ -436,11 +436,16 @@ def perform_post_job_with_state(context, metadata, job_id, state, token="without
 
 @when("I delete job without id")
 @when("I delete job with id {job_id}")
-def delete_job(context, job_id=None):
+@when("I delete job with id {job_id} {token} authorization token")
+def delete_job(context, job_id=None, token="without"):
     """API call to delete a job with given ID."""
     job_id = get_unique_job_id(context, job_id)
     endpoint = job_endpoint(context, job_id)
-    context.response = requests.delete(endpoint)
+    use_token = parse_token_clause(token)
+    if use_token:
+        context.response = requests.delete(endpoint, headers=jobs_api_authorization(context))
+    else:
+        context.response = requests.delete(endpoint)
 
 
 @when("I set status for job with id {job_id} to {status}")

--- a/integration-tests/features/steps/common.py
+++ b/integration-tests/features/steps/common.py
@@ -435,6 +435,7 @@ def perform_post_job_with_state(context, metadata, job_id, state, token="without
 
 
 @when("I delete job without id")
+@when("I delete job without id {token} authorization token")
 @when("I delete job with id {job_id}")
 @when("I delete job with id {job_id} {token} authorization token")
 def delete_job(context, job_id=None, token="without"):

--- a/integration-tests/features/steps/common.py
+++ b/integration-tests/features/steps/common.py
@@ -413,6 +413,13 @@ def perform_post_job(context, metadata, state, token="without"):
     send_json_file_to_job_api(context, endpoint, filename, use_token)
 
 
+def get_unique_job_id(context, job_id):
+    if context.job_id_prefix is not None:
+        return "{uuid}_{job_id}".format(uuid=context.job_id_prefix, job_id=job_id)
+    else:
+        return job_id
+
+
 @when("I post a job metadata {metadata} with job id {job_id} and state {state}")
 @when("I post a job metadata {metadata} with job id {job_id} and state {state} {token} "
       "authorization token")
@@ -421,6 +428,7 @@ def perform_post_job_with_state(context, metadata, job_id, state, token="without
     to given state. The token parameter can be set to 'with', 'without', or
     'using'."""
     filename = job_metadata_filename(metadata)
+    job_id = get_unique_job_id(context, job_id)
     endpoint = flow_sheduling_endpoint(context, state, job_id)
     use_token = parse_token_clause(token)
     send_json_file_to_job_api(context, endpoint, filename, use_token)
@@ -430,6 +438,7 @@ def perform_post_job_with_state(context, metadata, job_id, state, token="without
 @when("I delete job with id {job_id}")
 def delete_job(context, job_id=None):
     """API call to delete a job with given ID."""
+    job_id = get_unique_job_id(context, job_id)
     endpoint = job_endpoint(context, job_id)
     context.response = requests.delete(endpoint)
 
@@ -544,6 +553,7 @@ def find_job(context, job_id, state=None):
     """
     jsondata = context.response.json()
     jobs = jsondata['jobs']
+    job_id = get_unique_job_id(context, job_id)
     job_ids = [job["job_id"] for job in jobs]
     assert job_id in job_ids
     if state is not None:
@@ -560,6 +570,7 @@ def should_not_find_job_by_id(context, job_id):
     """
     jsondata = context.response.json()
     jobs = jsondata['jobs']
+    job_id = get_unique_job_id(context, job_id)
     job_ids = [job["job_id"] for job in jobs]
     assert job_id not in job_ids
 

--- a/integration-tests/features/steps/common.py
+++ b/integration-tests/features/steps/common.py
@@ -474,10 +474,15 @@ def set_job_service_status(context, status=None, token="without"):
 
 
 @when("I clean all failed jobs")
-def clean_all_failed_jobs(context):
+@when("I clean all failed jobs {token} authorization token")
+def clean_all_failed_jobs(context, token="without"):
     """API call to clean up all failed jobs."""
     url = "{url}api/v1/jobs/clean-failed".format(url=context.jobs_api_url)
-    context.response = requests.delete(url)
+    use_token = parse_token_clause(token)
+    if use_token:
+        context.response = requests.delete(url, headers=jobs_api_authorization(context))
+    else:
+        context.response = requests.delete(url)
 
 
 @when("I ask for analyses report for ecosystem {ecosystem}")

--- a/integration-tests/features/steps/common.py
+++ b/integration-tests/features/steps/common.py
@@ -414,7 +414,7 @@ def perform_post_job(context, metadata, state, token="without"):
 
 
 def get_unique_job_id(context, job_id):
-    if context.job_id_prefix is not None:
+    if 'job_id_prefix' in context:
         return "{uuid}_{job_id}".format(uuid=context.job_id_prefix, job_id=job_id)
     else:
         return job_id


### PR DESCRIPTION
Couple of smaller changes:

* optional usage of unique job IDs (a must on stage/production)
* use auth. token for delete a job
* use auth. token to cleanup jobs
* use auth. token to change the service state
* use auth. token to retrieve service state
* all tests should use proper auth. token
* other fixes to hopefully make CI tester happy :) [it actually does 🥇 ]