### PR TITLE
Increase timeout for the stack and component analysis

### DIFF
--- a/integration-tests/features/environment.py
+++ b/integration-tests/features/environment.py
@@ -24,8 +24,8 @@ _ANITYA_SERVICE = 31005
 _JOBS_DEBUG_API = _API_ENDPOINT + "/debug"
 
 # Default timeout values for the stack analysis and component analysis endpoints
-_DEFAULT_STACK_ANALYSIS_TIMEOUT = 600
-_DEFAULT_COMPONENT_ANALYSIS_TIMEOUT = 600
+_DEFAULT_STACK_ANALYSIS_TIMEOUT = 1200
+_DEFAULT_COMPONENT_ANALYSIS_TIMEOUT = 1200
 
 
 def _make_compose_name(suffix='.yml'):


### PR DESCRIPTION
Sometimes (but not very often) the tests failed on the stage due to stack analysis timeout. Let's increase the default timeout value to be on the safe side.