### PR TITLE
Disable tests which require auth in CentOS CI for now - no token

### DIFF
--- a/integration-tests/cico_run_tests.sh
+++ b/integration-tests/cico_run_tests.sh
@@ -13,5 +13,5 @@ docker run -t \
     -e F8A_JOB_API_URL=${F8A_JOB_API_URL} \
     -e F8A_ANITYA_API_URL=${F8A_ANITYA_API_URL} \
     ${RECOMMENDER_API_TOKEN:+-e RECOMMENDER_API_TOKEN=${RECOMMENDER_API_TOKEN}} \
-    f8a-e2e-tests --tags=-jobs.requires_auth --no-color $@
+    f8a-e2e-tests --tags=-jobs.requires_auth --tags=-requires_authorization_token --no-color $@
 

--- a/integration-tests/features/user_feedback.feature
+++ b/integration-tests/features/user_feedback.feature
@@ -4,6 +4,7 @@ Feature: Components API V1
     When I access /api/v1/
     Then I should get 200 status code
 
+  @requires_authorization_token
   Scenario: Check if the user feedback is received by the system
     Given System is running
     When I acquire the authorization token


### PR DESCRIPTION
There is still no token in CentOS CI...