### PR TITLE
Inserted missing return (quick, minor)

### DIFF
--- a/perf-tests/src/coreapi.py
+++ b/perf-tests/src/coreapi.py
@@ -56,4 +56,4 @@ class CoreApi(Api):
 
     def stack_analysis(self):
         job_id = self.start_stack_analysis()
-        self.wait_for_stack_analysis(job_id)
+        return self.wait_for_stack_analysis(job_id)


### PR DESCRIPTION
In order to display measured durations we need to be able to read the results