### PR TITLE
add github token for gh_most_stared api

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,6 +110,8 @@ services:
       #JOB_SERVICE_PORT: 34000
       DEPLOYMENT_PREFIX: "${USER}"
       DISABLE_AUTHENTICATION: "1"
+      #If we want to use gh_most_started api locally then need to put the right github-access token in below variable
+      GITHUB_ACCESS_TOKENS: ""
       # We use ingestion in deployment, but force to api here as we have only one worker that is serving api requests by default
       WORKER_ADMINISTRATION_REGION: api
       RABBITMQ_SERVICE_SERVICE_HOST: coreapi-broker


### PR DESCRIPTION
Add an environment variable for github token in Jobs as it is required to gh_most_stared api in local run. 