### PR TITLE
Do not provide S3 credentials on local setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,8 +120,8 @@ services:
       POSTGRESQL_DATABASE: coreapi
       PGBOUNCER_SERVICE_HOST: coreapi-pgbouncer
       F8A_UNCLOUDED_MODE: 'true'
-      AWS_S3_ACCESS_KEY_ID: GNV3SAHAHA3DOT99GQII
-      AWS_S3_SECRET_ACCESS_KEY: ZmvMwngonaDK5ymlCd6ptaalDdJsCn3aSSxASPaZ
+      #AWS_S3_ACCESS_KEY_ID: ''
+      #AWS_S3_SECRET_ACCESS_KEY: ''
       # Provide credentials here if you want to run on Amazon SQS instead of RabbitMQ, don't forget to supply
       # credentials even for server and worker
       # Both can be omitted, defaults to eu-west-1


### PR DESCRIPTION
Providing S3 credentials in local setup means that database adapters are trying to connect to remote S3 instead of the local one.