### PR TITLE
[Postgres] Update to latest version of common

### DIFF
--- a/postgres-docker/README.md
+++ b/postgres-docker/README.md
@@ -2,3 +2,5 @@ Centos7-PostgreSQL-9.4
 ======================
 
 Modified version of `registry.centos.org/sclo/postgresql-94-centos7:latest` to support multiple databases.
+
+In case there is any major change in `common.sh` run `./update_common.sh` and script applies changes to latest common.sh from upstream.

--- a/postgres-docker/multiple_dbs.patch
+++ b/postgres-docker/multiple_dbs.patch
@@ -1,0 +1,26 @@
+diff --git a/postgres-docker/common.sh b/postgres-docker/common.sh
+index 1e39b4f..0c54351 100644
+--- a/postgres-docker/common.sh
++++ b/postgres-docker/common.sh
+@@ -61,7 +61,8 @@ function check_env_vars() {
+     [[ -v POSTGRESQL_USER && -v POSTGRESQL_PASSWORD && -v POSTGRESQL_DATABASE ]] || usage
+     [[ "$POSTGRESQL_USER"     =~ $psql_identifier_regex ]] || usage
+     [[ "$POSTGRESQL_PASSWORD" =~ $psql_password_regex   ]] || usage
+-    [[ "$POSTGRESQL_DATABASE" =~ $psql_identifier_regex ]] || usage
++    # We know what we are doing, disable this check
++    #[[ "$POSTGRESQL_DATABASE" =~ $psql_identifier_regex ]] || usage
+     [ ${#POSTGRESQL_USER}     -le 63 ] || usage "PostgreSQL username too long (maximum 63 characters)"
+     [ ${#POSTGRESQL_DATABASE} -le 63 ] || usage "Database name too long (maximum 63 characters)"
+     postinitdb_actions+=",simple_db"
+@@ -164,7 +165,10 @@ EOF
+ function create_users() {
+   if [[ ",$postinitdb_actions," = *,simple_db,* ]]; then
+     createuser "$POSTGRESQL_USER"
+-    createdb --owner="$POSTGRESQL_USER" "$POSTGRESQL_DATABASE"
++    for database in ${POSTGRESQL_DATABASE//;/ }; do
++      echo "Creating database \"${database}\"..."
++      createdb --owner="$POSTGRESQL_USER" "$database"
++    done
+   fi
+ 
+   if [ -v POSTGRESQL_MASTER_USER ]; then

--- a/postgres-docker/update_common.sh
+++ b/postgres-docker/update_common.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-curl -o common.sh https://raw.githubusercontent.com/sclorg/postgresql-container/master/9.4/root/usr/share/container-scripts/postgresql/common.sh && patch common.sh < multiple_dbs.patch
+curl -o common.sh https://raw.githubusercontent.com/sclorg/postgresql-container/master/9.4/root/usr/share/container-scripts/postgresql/common.sh && patch < multiple_dbs.patch
 

--- a/postgres-docker/update_common.sh
+++ b/postgres-docker/update_common.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+curl -o common.sh https://raw.githubusercontent.com/sclorg/postgresql-container/master/9.4/root/usr/share/container-scripts/postgresql/common.sh && patch common.sh < multiple_dbs.patch
+


### PR DESCRIPTION
In recent update upstream of Postgres image, which we use introduced changes which can break our setup.

This PR extracts our changes in `common.sh` and adds scripts which download the latest version of `common.sh` and applies this changes.

I don't want to run update script in `Dockerfile`, because there is no patch binary available and default user is switched to Postgres.

If anybody thinks that it will be more transparent to move script inside `Dockerfile`, I will gladly do it.