### PR TITLE
Don't fail when core API returns HTTP 500 w/o any payload

### DIFF
--- a/perf-tests/src/api.py
+++ b/perf-tests/src/api.py
@@ -28,6 +28,9 @@ class Api:
         return requests.get(self.url)
 
     def print_error_response(self, response, message_key):
-        error_message = response.json().get(message_key, "Server does not sent error message")
         print("    Server returned HTTP code {c}".format(c=response.status_code))
-        print("    Error message: {m}".format(m=error_message))
+        try:
+            error_message = response.json().get(message_key, "Server does not sent error message")
+            print("    Error message: {m}".format(m=error_message))
+        except Exception:
+            pass   # no error message

--- a/perf-tests/src/api.py
+++ b/perf-tests/src/api.py
@@ -29,8 +29,11 @@ class Api:
 
     def print_error_response(self, response, message_key):
         print("    Server returned HTTP code {c}".format(c=response.status_code))
+        error_message = None
         try:
-            error_message = response.json().get(message_key, "Server does not sent error message")
-            print("    Error message: {m}".format(m=error_message))
+            error_message = response.json().get(message_key, "Server did not sent error message")
         except Exception:
             pass   # no error message
+
+        if error_message:
+            print("    Error message: {m}".format(m=error_message))


### PR DESCRIPTION
Just a quick fix not to fail when core API does not return error message.