### PR TITLE
E2e test change - remove outlier count validation tests

### DIFF
--- a/integration-tests/features/stack_analyses_v2_minimal.feature
+++ b/integration-tests/features/stack_analyses_v2_minimal.feature
@@ -29,7 +29,6 @@ Feature: Stack analysis v2 API Minimal
     Then I should get a valid request ID
     Then I should find the attribute request_id equals to id returned by stack analysis request
     Then I should find that none analyzed package can be found in companion packages as well
-    Then I should find that total 1 outliers are reported
     Then I should find that valid outliers are reported
     Then I should get license_analysis field in stack report
     Then I should find that alternate components replace user components
@@ -50,7 +49,6 @@ Feature: Stack analysis v2 API Minimal
     Then I should get a valid request ID
     Then I should find the attribute request_id equals to id returned by stack analysis request
     Then I should find that none analyzed package can be found in companion packages as well
-    Then I should find that total 2 outliers are reported
     Then I should find that valid outliers are reported
     Then I should get license_analysis field in stack report
     Then I should find that alternate components replace user components


### PR DESCRIPTION
We should not rely on e2e tests asserting count of outliers detected from recommendation service. Reason - Each time when a model is retrained with new datasets, this outlier, alternate and companion changes in terms of recommendations.