### PR TITLE
Adding 3scale credentials

### DIFF
--- a/openshift/secrets-template.yaml
+++ b/openshift/secrets-template.yaml
@@ -47,6 +47,14 @@ objects:
 - apiVersion: v1
   kind: Secret
   metadata:
+    name: 3scale
+  type: Opaque
+  data:
+    three_scale_api_access_key : ${THREE_SCALE_API_ACCESS_KEY}
+    three_scale_api_account_id : ${THREE_SCALE_API_ACCOUNT_ID}
+- apiVersion: v1
+  kind: Secret
+  metadata:
     name: worker
   type: Opaque
   data:


### PR DESCRIPTION
This commit adds 'three scale api access key'
and 'three scale api account' id as secret variables
in openshift template.