### PR TITLE
Configurable stack analysis manifest

### DIFF
--- a/perf-tests/data/junit.xml
+++ b/perf-tests/data/junit.xml
@@ -1,0 +1,13 @@
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.redhat.bayessian.test</groupId>
+  <artifactId>test-app-junit-dependency</artifactId>
+  <version>1.0</version>
+  <dependencies>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>3.8.1</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/perf-tests/data/springboot.xml
+++ b/perf-tests/data/springboot.xml
@@ -1,0 +1,33 @@
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.redhat.bayessian.test</groupId>
+  <artifactId>test-app-springboot</artifactId>
+  <version>1.0</version>
+  <dependencies>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-messaging</artifactId>
+      <version>4.3.7.RELEASE</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-websocket</artifactId>
+      <version>4.3.7.RELEASE</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <version>1.5.2.RELEASE</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter</artifactId>
+      <version>1.5.2.RELEASE</version>
+    </dependency>
+
+  </dependencies>
+</project>

--- a/perf-tests/data/vertx_3_4_1.xml
+++ b/perf-tests/data/vertx_3_4_1.xml
@@ -1,0 +1,51 @@
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.redhat.bayessian.test</groupId>
+  <artifactId>test-app-vertx</artifactId>
+  <version>1.0</version>
+  <dependencies>
+
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-core</artifactId>
+      <version>3.4.1</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-jdbc-client</artifactId>
+      <version>3.4.1</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-rx-java</artifactId>
+      <version>3.4.1</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web-client</artifactId>
+      <version>3.4.1</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web-templ-freemarker</artifactId>
+      <version>3.4.1</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web-templ-handlebars</artifactId>
+      <version>3.4.1</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web</artifactId>
+      <version>3.4.1</version>
+    </dependency>
+
+  </dependencies>
+</project>

--- a/perf-tests/data/vertx_3_4_2.xml
+++ b/perf-tests/data/vertx_3_4_2.xml
@@ -1,0 +1,51 @@
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.redhat.bayessian.test</groupId>
+  <artifactId>test-app-vertx</artifactId>
+  <version>1.0</version>
+  <dependencies>
+
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-core</artifactId>
+      <version>3.4.2</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-jdbc-client</artifactId>
+      <version>3.4.2</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-rx-java</artifactId>
+      <version>3.4.2</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web-client</artifactId>
+      <version>3.4.2</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web-templ-freemarker</artifactId>
+      <version>3.4.2</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web-templ-handlebars</artifactId>
+      <version>3.4.2</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-web</artifactId>
+      <version>3.4.2</version>
+    </dependency>
+
+  </dependencies>
+</project>

--- a/perf-tests/src/cliargs.py
+++ b/perf-tests/src/cliargs.py
@@ -59,3 +59,7 @@ cli_parser.add_argument('-H', '--generate-html',
 cli_parser.add_argument('--sla',
                         help='run only benchmarks that are needed for SLA acceptance',
                         action='store_true')
+
+cli_parser.add_argument('--manifest',
+                        help='manifest file (from the data directory) used for the stack analysis',
+                        type=str)

--- a/perf-tests/src/coreapi.py
+++ b/perf-tests/src/coreapi.py
@@ -60,7 +60,7 @@ class CoreApi(Api):
         filename = filename or 'requirements_click_6_star.txt'
         manifest_name = CoreApi.get_manifest_name(filename)
 
-        print("filename with manifest data: {m}".format(m=manifest_name))
+        print("filename with manifest data: {f}".format(f=filename))
         print("standard manifest name: {n}".format(n=manifest_name))
 
         filename = 'data/{filename}'.format(filename=filename)

--- a/perf-tests/src/coreapi.py
+++ b/perf-tests/src/coreapi.py
@@ -11,6 +11,16 @@ class CoreApi(Api):
     def __init__(self, url, token):
         """Set the API endpoint and store the authorization token if provided."""
         super().__init__(url, token)
+        self._stack_analysis_manifest = None
+
+    @property
+    def stack_analysis_manifest(self):
+        """Getter to retrieve the stack analysis manifest name."""
+        return self._stack_analysis_manifest
+
+    @stack_analysis_manifest.setter
+    def stack_analysis_manifest(self, filename):
+        self._stack_analysis_manifest = filename
 
     def authorization(self):
         """Return a HTTP header with authorization token."""

--- a/perf-tests/src/coreapi.py
+++ b/perf-tests/src/coreapi.py
@@ -41,13 +41,39 @@ class CoreApi(Api):
         return bool(result) and isinstance(result, list) \
             and (result[0].get('recommendation', {}) or {}).get('alternate', None) is not None
 
-    def start_stack_analysis(self):
-        """Start the stack analysis, sending the manifest file."""
-        filename = 'data/requirements_click_6_star.txt'
+    @staticmethod
+    def get_manifest_name(filename):
+        """Get the standard manifest name for the given filename."""
+        manifests = {
+            ".txt": "requirements.txt",
+            ".xml": "pom.xml",
+            ".json": "package.json"}
+        for extension, manifest in manifests.items():
+            if filename.endswith(extension):
+                return manifest
+        raise "Unknown extension in filename: {f}".format(f=filename)
+
+    @staticmethod
+    def prepare_manifest_files(filename):
+        """Send the selected manifest file to stack analysis."""
+        # default variable substitutions
+        filename = filename or 'requirements_click_6_star.txt'
+        manifest_name = CoreApi.get_manifest_name(filename)
+
+        print("filename with manifest data: {m}".format(m=manifest_name))
+        print("standard manifest name: {n}".format(n=manifest_name))
+
+        filename = 'data/{filename}'.format(filename=filename)
         manifest_file_dir = os.path.dirname(filename)
         path_to_manifest_file = os.path.abspath(manifest_file_dir)
-        files = {'manifest[]': ("requirements.txt", open(filename, 'rb')),
+
+        files = {'manifest[]': (manifest_name, open(filename, 'rb')),
                  'filePath[]': (None, path_to_manifest_file)}
+        return files
+
+    def start_stack_analysis(self):
+        """Start the stack analysis, sending the manifest file."""
+        files = CoreApi.prepare_manifest_files(self._stack_analysis_manifest)
         endpoint = self.url + 'api/v1/stack-analyses'
         response = requests.post(endpoint, files=files, headers=self.authorization())
         response.raise_for_status()

--- a/perf-tests/src/perf-tests.py
+++ b/perf-tests/src/perf-tests.py
@@ -620,6 +620,8 @@ def main():
 
     check_system(core_api, jobs_api, s3)
 
+    core_api.stack_analysis_manifest = cli_arguments.manifest
+
     if cli_arguments.sla:
         run_benchmarks_sla(core_api, jobs_api, s3)
     else:


### PR DESCRIPTION
Support for the following call:

```
./runtest.sh -S --manifest=vertx_3_4_2.xml
```

ie. it is possible to specify manifest file that will be sent for the stack analysis.