### PR TITLE
Timestamp checks

### DIFF
--- a/integration-tests/features/gremlin.feature
+++ b/integration-tests/features/gremlin.feature
@@ -137,3 +137,10 @@ Feature: Check the Gremlin instance and its behaviour
       And I should find that all found packages have valid timestamp with the last update time
       And I should find that the package data is older than remembered time
 
+  @requires_access_to_graph_db
+  Scenario: Basic check for Gremlin ability to read last update timestamp for the selected package
+    Given System is running
+    When I read the last update time for the package clojure_py version 0.2.4 in the ecosystem pypi
+    Then I should get 200 status code
+     And I should get valid Gremlin response
+     And I should get a valid timestamp represented as UNIX time

--- a/integration-tests/features/gremlin.feature
+++ b/integration-tests/features/gremlin.feature
@@ -131,6 +131,9 @@ Feature: Check the Gremlin instance and its behaviour
   Scenario: Basic check for Gremlin ability to search for given package
     Given System is running
     When I ask Gremlin to find the package sequence in the ecosystem npm
+     And I remember the current time
     Then I should get 200 status code
      And I should get valid Gremlin response
+      And I should find that all found packages have valid timestamp with the last update time
+      And I should find that the package data is older than remembered time
 

--- a/integration-tests/features/src/graph_db_query.py
+++ b/integration-tests/features/src/graph_db_query.py
@@ -28,6 +28,16 @@ class Query:
         self.query += '.count()'
         return self
 
+    def first(self):
+        """Append a clause to get the first result from a list."""
+        self.query += '[0]'
+        return self
+
+    def value(self, value):
+        """Append a clause to read the given value from the dictionary."""
+        self.query += '.value("{value}")'.format(value=value)
+        return self
+
     def __repr__(self):
         """Return an official represenation of the object, same as __str__ here."""
         return self.query

--- a/integration-tests/features/steps/gremlin.py
+++ b/integration-tests/features/steps/gremlin.py
@@ -62,6 +62,16 @@ def remember_current_time(context):
     context.current_time = time.time()
 
 
+@when('I read the last update time for the package {package:S} version {version} in the ecosystem'
+      ' {ecosystem}')
+def gremlin_read_last_update_time(context, package, version, ecosystem):
+    """Read the last update timestamp."""
+    query = Query().has("pecosystem", ecosystem).has("pname", package).has("version", version).\
+        first().value("last_updated")
+    print(query)
+    post_query(context, query)
+
+
 def post_query(context, query):
     """Post the already constructed query to the Gremlin."""
     data = {"gremlin": str(query)}
@@ -198,6 +208,15 @@ def check_unexpected_properties_in_results(context, properties):
             if prop not in expected_properties:
                 raise Exception("Unexpected property has been found: {prop}".format(
                                 prop=prop))
+
+
+@then('I should get a valid timestamp represented as UNIX time')
+def check_unix_timestamp(context):
+    """Check that only proper timestamp is returned in Gremlin response."""
+    data, meta = get_results_from_gremlin(context)
+    assert len(data) == 1
+    timestamp = data[0]
+    assert type(timestamp) is float
 
 
 @then('I should find that the {property_name} property is set to {expected_value} in the package '

--- a/integration-tests/features/steps/gremlin.py
+++ b/integration-tests/features/steps/gremlin.py
@@ -68,7 +68,6 @@ def gremlin_read_last_update_time(context, package, version, ecosystem):
     """Read the last update timestamp."""
     query = Query().has("pecosystem", ecosystem).has("pname", package).has("version", version).\
         first().value("last_updated")
-    print(query)
     post_query(context, query)
 
 


### PR DESCRIPTION
The new tests are not much useful, but we'd need to have the timestamp check for the following tests that will wait for the analysis (started from jobs API) to finish.