### PR TITLE
Use 'oc get project' instead of grep

### DIFF
--- a/openshift/deploy.sh
+++ b/openshift/deploy.sh
@@ -90,8 +90,8 @@ function oc_process_apply() {
 }
 
 function openshift_login() {
-    if oc login $OC_URI -u $OC_USERNAME -p $OC_PASSWD | grep -q $OC_PROJECT
-    then
+    oc login $OC_URI -u $OC_USERNAME -p $OC_PASSWD
+    if oc get project $OC_PROJECT; then
         oc project $OC_PROJECT
         echo "Removing all openshift resources from selected project"
         oc delete all,cm,secrets --all


### PR DESCRIPTION
In some cases (in container) the 'oc login' shows only `<default>` project
even the OC_PROJECT exists.