### PR TITLE
Change in status code for a 3scale test.

### DIFF
--- a/integration-tests/features/three_scale.feature
+++ b/integration-tests/features/three_scale.feature
@@ -3,7 +3,7 @@ Feature: 3scale API
     Scenario: Check if 3scale staging url requires authentication
         Given 3scale staging pod is running
         When I access get_route API end point for 3scale without authorization
-        Then I should get 400 status code
+        Then I should get 404 status code
 
     @requires_authorization_token
     Scenario: Check the POST API endpoint get-route returns the required information


### PR DESCRIPTION
This change is in accordance to the change of status code in 3scale-connect-api.
reference:-
https://github.com/fabric8-analytics/f8a-3scale-connect-api/pull/22