### PR TITLE
Timestamp on dashboard

### DIFF
--- a/dashboard/src/html_generator.py
+++ b/dashboard/src/html_generator.py
@@ -19,6 +19,7 @@ def generate_details_page_for_repository(repository, results):
     data["line_counts"] = results.source_files[repository]["line_counts"]
     data["linter_checks"] = results.repo_linter_checks[repository]["files"]
     data["docstyle_checks"] = results.repo_docstyle_checks[repository]["files"]
+    data["generated_on"] = results.generated_on
     generated_page = template.render(**data)
     filename = "repository_{repository}.html".format(repository=repository)
     with open(filename, "w") as fout:

--- a/dashboard/src/results.py
+++ b/dashboard/src/results.py
@@ -1,5 +1,7 @@
 """Results gathered by the Dashboard to be published."""
 
+import time
+
 
 class Results():
     """Class representing results gathered by the Dashboard to be published."""
@@ -23,6 +25,7 @@ class Results():
         self.f = lambda number: '{0:.2f}'.format(number)  # function to format floating point number
         self.sla = {}
         self.smoke_tests_results = {}
+        self.generated_on = time.strftime('%Y-%m-%d %H:%M:%S')
 
     def __repr__(self):
         """Return textual representation of all results."""

--- a/dashboard/template/dashboard.html
+++ b/dashboard/template/dashboard.html
@@ -161,6 +161,7 @@
             </div>
             <div style='height:100px'></div>
             <div>Author: Pavel Tisnovsky &lt;<a href="mailto:ptisnovs@redhat.com">ptisnovs@redhat.com</a>&gt;</div>
+            <div>Generated on: ${generated_on}</div>
         </div>
     </body>
 </html>

--- a/dashboard/template/repo_details.html
+++ b/dashboard/template/repo_details.html
@@ -52,6 +52,7 @@
             </div>
             <div style='height:100px'></div>
             <div>Author: Pavel Tisnovsky &lt;<a href="mailto:ptisnovs@redhat.com">ptisnovs@redhat.com</a>&gt;</div>
+            <div>Generated on: ${generated_on}</div>
         </div>
     </body>
 </html>


### PR DESCRIPTION
Display timestamp at the end of all generated pages, like:
https://fabric8-analytics.github.io/dashboard/dashboard.html

and

https://fabric8-analytics.github.io/dashboard/repository_fabric8-analytics-common.html