### PR TITLE
[openshift/deploy.sh] delete previously allocated AWS resources

### DIFF
--- a/openshift/README.md
+++ b/openshift/README.md
@@ -39,6 +39,12 @@ Just run the deploy script and enjoy!
 If you have already run the script previously and therefore there exists a `$OC_PROJECT` project, the script purges it to start from scratch.
 It also purges all existing `$DEPLOYMENT_PREFIX` prefixed AWS resources (RDS db, SQS queues, S3 buckets, DynamoDB tables) - this can be avoided by using `--keep-resources` argument.
 
+Once you know that you no longer need the fabric8-analytics deployment, you can run
+
+`$./cleanup.sh`
+
+to remove the Openshift project and all allocated AWS resources.
+
 ## Deploy your changes to dev-cluster
 
 Assume you have opened a PR in one of the [fabric8-analytics](https://github.com/fabric8-analytics) repositories.

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -36,6 +36,9 @@ Just run the deploy script and enjoy!
 
 `$./deploy.sh`
 
+If you have already run the script previously and therefore there exists a `$OC_PROJECT` project, the script purges it to start from scratch.
+It also purges all existing `$DEPLOYMENT_PREFIX` prefixed AWS resources (RDS db, SQS queues, S3 buckets, DynamoDB tables) - this can be avoided by using `--keep-resources` argument.
+
 ## Deploy your changes to dev-cluster
 
 Assume you have opened a PR in one of the [fabric8-analytics](https://github.com/fabric8-analytics) repositories.

--- a/openshift/README.md
+++ b/openshift/README.md
@@ -37,7 +37,9 @@ Just run the deploy script and enjoy!
 `$./deploy.sh`
 
 If you have already run the script previously and therefore there exists a `$OC_PROJECT` project, the script purges it to start from scratch.
-It also purges all existing `$DEPLOYMENT_PREFIX` prefixed AWS resources (RDS db, SQS queues, S3 buckets, DynamoDB tables) - this can be avoided by using `--keep-resources` argument.
+If you want to also purge previously allocated AWS resources (RDS db, SQS queues, S3 buckets, DynamoDB tables) use
+
+`$./deploy.sh --purge-aws-resources`
 
 Once you know that you no longer need the fabric8-analytics deployment, you can run
 

--- a/openshift/cleanup.sh
+++ b/openshift/cleanup.sh
@@ -1,0 +1,39 @@
+#!/bin/bash -e
+
+# Remove fabric8-analytics project from Openshift along with allocated AWS resources.
+
+# This script can eventually be merged with deploy.sh
+
+here=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+source helpers.sh
+
+#Check for configuration file
+if ! [ -f "${here}/env.sh" ]
+then
+    echo '`env.sh` configuration file is missing. You can create one from the template:'
+    echo 'cp env-template.sh env.sh'
+    echo
+    echo 'Modify the `env.sh` configuration file as necessary. See README.md file for more information.'
+    exit 1
+fi
+
+#Check if required commands are available
+tool_is_installed aws
+tool_is_installed awk
+tool_is_installed psql
+tool_is_installed oc
+
+#Load configuration from env variables
+source env.sh
+
+#Check if required env variables are set
+is_set_or_fail RDS_PASSWORD "${RDS_PASSWORD}"
+is_set_or_fail RDS_INSTANCE_NAME "${RDS_INSTANCE_NAME}"
+is_set_or_fail OC_USERNAME "${OC_USERNAME}"
+is_set_or_fail OC_PASSWD "${OC_PASSWD}"
+is_set_or_fail AWS_ACCESS_KEY_ID "${AWS_ACCESS_KEY_ID}"
+is_set_or_fail AWS_SECRET_ACCESS_KEY "${AWS_SECRET_ACCESS_KEY}"
+
+openshift_login
+delete_project_and_aws_resources

--- a/openshift/deploy.sh
+++ b/openshift/deploy.sh
@@ -2,7 +2,7 @@
 
 # Deploy fabric8-analytics to Openshift
 # possible arguments:
-#   --keep-aws-resources: do not clear previously allocated AWS resources
+#   --purge-aws-resources: clear previously allocated AWS resources (SQS queues, S3 buckets, DynamoDB tables)
 
 here=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
@@ -41,11 +41,11 @@ fabric8-analytics-worker fabric8-analytics-pgbouncer gremlin-docker
 fabric8-analytics-scaler fabric8-analytics-firehose-fetcher
 fabric8-analytics-license-analysis fabric8-analytics-stack-analysis fabric8-analytics-stack-report-ui"
 
-clean_aws_resources=true # default
+purge_aws_resources=false # default
 for key in "$@"; do
     case $key in
-        --keep-aws-resources)
-            clean_aws_resources=false
+        --purge-aws-resources)
+            purge_aws_resources=true
             shift # next argument
             ;;
         *)  # unknown option

--- a/openshift/deploy.sh
+++ b/openshift/deploy.sh
@@ -1,5 +1,9 @@
 #!/bin/bash -e
 
+# Deploy fabric8-analytics to Openshift
+# possible arguments:
+#   --keep-aws-resources: do not clear previously allocated AWS resources
+
 here=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 source helpers.sh
@@ -37,7 +41,21 @@ fabric8-analytics-worker fabric8-analytics-pgbouncer gremlin-docker
 fabric8-analytics-scaler fabric8-analytics-firehose-fetcher
 fabric8-analytics-license-analysis fabric8-analytics-stack-analysis fabric8-analytics-stack-report-ui"
 
+clean_aws_resources=true # default
+for key in "$@"; do
+    case $key in
+        --keep-aws-resources)
+            clean_aws_resources=false
+            shift # next argument
+            ;;
+        *)  # unknown option
+            shift # next argument
+            ;;
+    esac
+done
+
 openshift_login
+create_or_reuse_project
 allocate_aws_rds
 generate_and_deploy_config
 deploy_secrets

--- a/openshift/helpers.sh
+++ b/openshift/helpers.sh
@@ -65,6 +65,14 @@ function remove_project_resources() {
     fi
 }
 
+function delete_project_and_aws_resources() {
+    if oc get project "${OC_PROJECT}"; then
+        echo "Deleting project ${OC_PROJECT}"
+        oc delete project "${OC_PROJECT}"
+    fi
+    purge_aws_resources
+}
+
 function create_or_reuse_project() {
     if oc get project "${OC_PROJECT}"; then
         oc project "${OC_PROJECT}"

--- a/openshift/helpers.sh
+++ b/openshift/helpers.sh
@@ -43,7 +43,8 @@ function deploy_secrets() {
 
 function oc_process_apply() {
     echo -e "\\n Processing template - $1 ($2) \\n"
-    oc process -f $1 $2 | oc apply -f -
+    # Don't quote $2 as we need it to split into individual arguments
+    oc process -f "$1" $2 | oc apply -f -
 }
 
 function openshift_login() {

--- a/openshift/helpers.sh
+++ b/openshift/helpers.sh
@@ -60,7 +60,7 @@ function purge_aws_resources() {
 function remove_project_resources() {
     echo "Removing all openshift resources from selected project"
     oc delete all,cm,secrets --all
-    if [ "$clean_aws_resources" == true ] ; then
+    if [ "$purge_aws_resources" == true ]; then
         purge_aws_resources
     fi
 }
@@ -115,7 +115,7 @@ function allocate_aws_rds() {
     else
         echo "DB instance ${RDS_INSTANCE_NAME} already exists"
         wait_for_rds_instance_info
-        if [ "$clean_aws_resources" == true ] ; then
+        if [ "$purge_aws_resources" == true ]; then
             echo "recreating database"
             PGPASSWORD="${RDS_PASSWORD}" psql -d template1 -h "${RDS_ENDPOINT}" -U "${RDS_DBADMIN}" -c "drop database ${RDS_DBNAME}"
             PGPASSWORD="${RDS_PASSWORD}" psql -d template1 -h "${RDS_ENDPOINT}" -U "${RDS_DBADMIN}" -c "create database ${RDS_DBNAME}"

--- a/openshift/helpers.sh
+++ b/openshift/helpers.sh
@@ -51,9 +51,18 @@ function openshift_login() {
     oc login "${OC_URI}" -u "${OC_USERNAME}" -p "${OC_PASSWD}" --insecure-skip-tls-verify=true
 }
 
+function purge_aws_resources() {
+    echo "Removing previously allocated AWS resources"
+    # Purges $DEPLOYMENT_PREFIX prefixed SQS queues, S3 buckets and DynamoDB tables.
+    python3 ./purge_AWS_resources.py
+}
+
 function remove_project_resources() {
     echo "Removing all openshift resources from selected project"
     oc delete all,cm,secrets --all
+    if [ "$clean_aws_resources" == true ] ; then
+        purge_aws_resources
+    fi
 }
 
 function create_or_reuse_project() {

--- a/openshift/purge_AWS_resources.py
+++ b/openshift/purge_AWS_resources.py
@@ -2,7 +2,10 @@
 
 """Operations to purge/delete previously allocated AWS resources."""
 
+import argparse
 import boto3
+from botocore.exceptions import ClientError
+from itertools import chain
 from os import getenv
 from sys import exit
 
@@ -15,63 +18,148 @@ _DEPLOYMENT_PREFIX = getenv('DEPLOYMENT_PREFIX')
 class AWSCleaner(object):
     """Operations to purge/delete previously allocated AWS resources."""
 
-    @staticmethod
-    def purge_sqs_queues():
-        """Remove messages in _DEPLOYMENT_PREFIX_[ingestion|api]_ prefixed queues."""
+    def __init__(self, tag):
+        """Initialize object."""
+        self.tag = tag
+
+    def purge_sqs_queues(self):
+        """Purge/Delete SQS queues.
+
+        If tag was specified during object creation, then delete all queues tagged with this tag.
+        Else purge (remove messages from) all _DEPLOYMENT_PREFIX_ prefixed queues.
+        """
         client = boto3.client('sqs',
                               aws_access_key_id=_AWS_ACCESS_KEY_ID,
                               aws_secret_access_key=_AWS_SECRET_ACCESS_KEY,
                               region_name=_AWS_DEFAULT_REGION)
-
-        # Supply more than just _DEPLOYMENT_PREFIX to QueueNamePrefix to avoid purging wrong queues.
-        queues_urls = \
-            client.list_queues(QueueNamePrefix=_DEPLOYMENT_PREFIX + '_ingestion_').get('QueueUrls',
-                                                                                       []) +\
-            client.list_queues(QueueNamePrefix=_DEPLOYMENT_PREFIX + '_api_').get('QueueUrls', [])
-
-        for qurl in queues_urls:
-            print("Purging ", qurl)
-            client.purge_queue(QueueUrl=qurl)
-            # client.delete_queue(QueueUrl=qurl)
-
-    @staticmethod
-    def purge_s3_buckets():
-        """Remove objects (and versions) in _DEPLOYMENT_PREFIX-bayesian-core- prefixed buckets."""
-        s3 = boto3.resource('s3',
-                            aws_access_key_id=_AWS_ACCESS_KEY_ID,
-                            aws_secret_access_key=_AWS_SECRET_ACCESS_KEY,
-                            region_name=_AWS_DEFAULT_REGION)
-
-        for bucket in s3.buckets.all():
-            if bucket.name.startswith(_DEPLOYMENT_PREFIX + '-bayesian-core-'):
-                print("Purging ", bucket)
-                bucket.object_versions.delete()
-                bucket.objects.delete()
-                # All objects (including all object versions and Delete Markers) in the bucket
-                # must be deleted before the bucket itself can be deleted.
-                # bucket.delete()
-
-    @staticmethod
-    def delete_dynamodb_tables():
-        """Delete _DEPLOYMENT_PREFIX_ prefixed tables."""
-        dynamodb = boto3.resource('dynamodb',
+        resource = boto3.resource('sqs',
                                   aws_access_key_id=_AWS_ACCESS_KEY_ID,
                                   aws_secret_access_key=_AWS_SECRET_ACCESS_KEY,
                                   region_name=_AWS_DEFAULT_REGION)
 
-        for table in dynamodb.tables.all():
-            if table.name.startswith(_DEPLOYMENT_PREFIX + '_'):
-                # There's no 'purge' operation, so just delete the table.
-                print("Deleting ", table)
+        if self.tag:
+            print("About to delete SQS queues tagged with %r. "
+                  "It'll take a while to go through all queues, stay tuned." % ','.join(self.tag))
+            for queue in resource.queues.all():
+                tags = client.list_queue_tags(QueueUrl=queue.url).get('Tags', {})
+                if tags.get(self.tag[0]) == self.tag[1]:
+                    print("Deleting", queue.url)
+                    client.delete_queue(QueueUrl=queue.url)
+        else:
+            print("About to purge %r prefixed SQS queues." % _DEPLOYMENT_PREFIX)
+            for queue in chain(
+                    # Supply more than just _DEPLOYMENT_PREFIX to QueueNamePrefix
+                    # to avoid purging wrong queues.
+                    resource.queues.filter(QueueNamePrefix=_DEPLOYMENT_PREFIX + '_api_'),
+                    resource.queues.filter(QueueNamePrefix=_DEPLOYMENT_PREFIX + '_ingestion_'),
+                    resource.queues.filter(QueueNamePrefix=_DEPLOYMENT_PREFIX + '_priority_'),
+                    resource.queues.filter(QueueNamePrefix=_DEPLOYMENT_PREFIX + '_livenessFlow_')):
+                print("Deleting messages from", queue.url)
+                client.purge_queue(QueueUrl=queue.url)
+
+    def purge_s3_buckets(self):
+        """Purge/Delete S3 buckets.
+
+        If tag was specified during object creating, then delete all buckets tagged with this tag.
+        Else purge (remove objects from) all _DEPLOYMENT_PREFIX_ prefixed buckets.
+        """
+        s3 = boto3.resource('s3',
+                            aws_access_key_id=_AWS_ACCESS_KEY_ID,
+                            aws_secret_access_key=_AWS_SECRET_ACCESS_KEY,
+                            region_name=_AWS_DEFAULT_REGION)
+        if self.tag:
+            print("About to delete S3 buckets tagged with %r." % ','.join(self.tag))
+        else:
+            print("About to purge %r prefixed S3 buckets." % _DEPLOYMENT_PREFIX)
+
+        for bucket in s3.buckets.all():
+            match = False
+            if self.tag:
+                try:
+                    # bucket is either tagged with tag argument
+                    match = {'Key': self.tag[0], 'Value': self.tag[1]} in \
+                            s3.BucketTagging(bucket.name).tag_set
+                except ClientError:
+                    pass
+            # or name is _DEPLOYMENT_PREFIX prefixed
+            elif bucket.name.startswith(_DEPLOYMENT_PREFIX + '-bayesian-core-'):
+                match = True
+
+            if match:
+                print("Deleting", bucket) if self.tag else print("Deleting objects from", bucket)
+                bucket.object_versions.delete()
+                bucket.objects.delete()
+                if self.tag:
+                    # All objects (including all object versions and Delete Markers) in the bucket
+                    # must be deleted before the bucket itself can be deleted.
+                    bucket.delete()
+
+    def delete_dynamodb_tables(self):
+        """Purge/Delete DynamoDB tables.
+
+        If tag was specified during object creating, then delete all tables tagged with this tag.
+        Else delete all _DEPLOYMENT_PREFIX_ prefixed tables.
+        """
+        client = boto3.client('dynamodb',
+                              aws_access_key_id=_AWS_ACCESS_KEY_ID,
+                              aws_secret_access_key=_AWS_SECRET_ACCESS_KEY,
+                              region_name=_AWS_DEFAULT_REGION)
+        resource = boto3.resource('dynamodb',
+                                  aws_access_key_id=_AWS_ACCESS_KEY_ID,
+                                  aws_secret_access_key=_AWS_SECRET_ACCESS_KEY,
+                                  region_name=_AWS_DEFAULT_REGION)
+
+        if self.tag:
+            print("About to delete DynamoDB tables tagged with %r." % ','.join(self.tag))
+        else:
+            print("About to delete %r prefixed DynamoDB tables." % _DEPLOYMENT_PREFIX)
+
+        for table in resource.tables.all():
+            match = False
+            if self.tag:
+                # table is either tagged with tag argument
+                match = {'Key': self.tag[0], 'Value': self.tag[1]} in\
+                        client.list_tags_of_resource(ResourceArn=table.table_arn).get('Tags', [])
+            # or table name is _DEPLOYMENT_PREFIX prefixed
+            elif table.name.startswith(_DEPLOYMENT_PREFIX + '_'):
+                match = True
+
+            if match:
+                # There's no 'purge' operation, so just delete the table in any case.
+                print("Deleting", table)
                 table.delete()
 
 
 if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-f", "--force",
+                        help="Allow to purge/delete resources tagged/prefixed with prod or stage")
+    parser.add_argument("-t", "--tag",
+                        help="Delete resources tagged with this 'key,value' tag")
+    args = parser.parse_args()
+
     if not all(_AWS_ACCESS_KEY_ID and _AWS_SECRET_ACCESS_KEY and _AWS_DEFAULT_REGION and
                _DEPLOYMENT_PREFIX):
-        print("Not all environment variables are properly defined")
+        print("Not all environment variables are properly defined.")
         exit(1)
 
-    AWSCleaner.purge_sqs_queues()
-    AWSCleaner.purge_s3_buckets()
-    AWSCleaner.delete_dynamodb_tables()
+    if args.tag:
+        try:
+            k, v = args.tag.split(',')
+            args.tag = (k, v)
+        except ValueError:
+            print("Tag needs to be 'key,value'")
+            exit(1)
+        print("About to delete resources tagged with %r" % ','.join(args.tag))
+    else:
+        print("About to purge %r prefixed resources." % _DEPLOYMENT_PREFIX)
+
+    if (args.tag and args.tag[1].lower() in {'prod', 'stage'}
+            or _DEPLOYMENT_PREFIX.lower() in {'prod', 'stage'}) and not args.force:
+        print("If you really want to destroy prod/stage use -f/--force.")
+        exit(0)
+
+    aws_cleaner = AWSCleaner(args.tag)
+    aws_cleaner.purge_sqs_queues()
+    aws_cleaner.purge_s3_buckets()
+    aws_cleaner.delete_dynamodb_tables()

--- a/openshift/purge_AWS_resources.py
+++ b/openshift/purge_AWS_resources.py
@@ -1,0 +1,77 @@
+#!/usr/bin/python3
+
+"""Operations to purge/delete previously allocated AWS resources."""
+
+import boto3
+from os import getenv
+from sys import exit
+
+_AWS_ACCESS_KEY_ID = getenv('AWS_ACCESS_KEY_ID')
+_AWS_SECRET_ACCESS_KEY = getenv('AWS_SECRET_ACCESS_KEY')
+_AWS_DEFAULT_REGION = getenv('AWS_DEFAULT_REGION')
+_DEPLOYMENT_PREFIX = getenv('DEPLOYMENT_PREFIX')
+
+
+class AWSCleaner(object):
+    """Operations to purge/delete previously allocated AWS resources."""
+
+    @staticmethod
+    def purge_sqs_queues():
+        """Remove messages in _DEPLOYMENT_PREFIX_[ingestion|api]_ prefixed queues."""
+        client = boto3.client('sqs',
+                              aws_access_key_id=_AWS_ACCESS_KEY_ID,
+                              aws_secret_access_key=_AWS_SECRET_ACCESS_KEY,
+                              region_name=_AWS_DEFAULT_REGION)
+
+        # Supply more than just _DEPLOYMENT_PREFIX to QueueNamePrefix to avoid purging wrong queues.
+        queues_urls = \
+            client.list_queues(QueueNamePrefix=_DEPLOYMENT_PREFIX + '_ingestion_').get('QueueUrls',
+                                                                                       []) +\
+            client.list_queues(QueueNamePrefix=_DEPLOYMENT_PREFIX + '_api_').get('QueueUrls', [])
+
+        for qurl in queues_urls:
+            print("Purging ", qurl)
+            client.purge_queue(QueueUrl=qurl)
+            # client.delete_queue(QueueUrl=qurl)
+
+    @staticmethod
+    def purge_s3_buckets():
+        """Remove objects (and versions) in _DEPLOYMENT_PREFIX-bayesian-core- prefixed buckets."""
+        s3 = boto3.resource('s3',
+                            aws_access_key_id=_AWS_ACCESS_KEY_ID,
+                            aws_secret_access_key=_AWS_SECRET_ACCESS_KEY,
+                            region_name=_AWS_DEFAULT_REGION)
+
+        for bucket in s3.buckets.all():
+            if bucket.name.startswith(_DEPLOYMENT_PREFIX + '-bayesian-core-'):
+                print("Purging ", bucket)
+                bucket.object_versions.delete()
+                bucket.objects.delete()
+                # All objects (including all object versions and Delete Markers) in the bucket
+                # must be deleted before the bucket itself can be deleted.
+                # bucket.delete()
+
+    @staticmethod
+    def delete_dynamodb_tables():
+        """Delete _DEPLOYMENT_PREFIX_ prefixed tables."""
+        dynamodb = boto3.resource('dynamodb',
+                                  aws_access_key_id=_AWS_ACCESS_KEY_ID,
+                                  aws_secret_access_key=_AWS_SECRET_ACCESS_KEY,
+                                  region_name=_AWS_DEFAULT_REGION)
+
+        for table in dynamodb.tables.all():
+            if table.name.startswith(_DEPLOYMENT_PREFIX + '_'):
+                # There's no 'purge' operation, so just delete the table.
+                print("Deleting ", table)
+                table.delete()
+
+
+if __name__ == '__main__':
+    if not all(_AWS_ACCESS_KEY_ID and _AWS_SECRET_ACCESS_KEY and _AWS_DEFAULT_REGION and
+               _DEPLOYMENT_PREFIX):
+        print("Not all environment variables are properly defined")
+        exit(1)
+
+    AWSCleaner.purge_sqs_queues()
+    AWSCleaner.purge_s3_buckets()
+    AWSCleaner.delete_dynamodb_tables()


### PR DESCRIPTION
Please review with care as this is potentially destroying functionality.

1.  Previously if we found already existing RDS database, we were recreating it.
With this change we by default purge also previously allocated (`$DEPLOYMENT_PREFIX` prefixed) SQS queues, S3 buckets, DynamoDB tables.
The purging can be avoided by using `--keep-resources` argument.
The question is whether we by default really want to purge all those AWS resources, or whether we by default want to keep some of them (like S3 buckets?) ?

2. The new `hack/purge_AWS_resources.py` has also a `-t/--tag` option, which when specified, causes the script to delete all AWS resources [tagged](https://github.com/openshiftio/openshift.io/issues/1081) with this tag.
Fixes https://github.com/openshiftio/openshift.io/issues/1330 

