### PR TITLE
Issue 1794: The QA Dashboard should display current status of the e2e tests for the production environment

### DIFF
--- a/dashboard/config.ini
+++ b/dashboard/config.ini
@@ -10,4 +10,4 @@ label=team/analytics/core
 label=team/analytics/integration
 
 [sprint]
-number=143
+number=144

--- a/dashboard/src/dashboard.py
+++ b/dashboard/src/dashboard.py
@@ -405,9 +405,14 @@ def store_jobs_statuses(filename, data):
         fout.write(data)
 
 
-def jenkins_api_query(jenkins_url):
+def jenkins_api_query_job_statuses(jenkins_url):
     """Construct API query to Jenkins (CI)."""
     return "{url}/api/json?tree=jobs[name,color]".format(url=jenkins_url)
+
+
+def jenkins_api_query_build_statuses(jenkins_url):
+    """Construct API query to Jenkins (CI)."""
+    return "{url}/api/json?tree=builds[result]".format(url=jenkins_url)
 
 
 def jobs_as_dict(raw_jobs):
@@ -417,7 +422,7 @@ def jobs_as_dict(raw_jobs):
 
 def read_ci_jobs_statuses(jenkins_url):
     """Read statuses of all jobs from the Jenkins (CI)."""
-    api_query = jenkins_api_query(jenkins_url)
+    api_query = jenkins_api_query_job_statuses(jenkins_url)
     response = requests.get(api_query)
     raw_jobs = response.json()["jobs"]
 
@@ -434,6 +439,17 @@ def read_job_statuses(ci_jobs, ci_jobs_table_enabled, liveness_table_enabled):
         return read_ci_jobs_statuses(JENKINS_URL)
     else:
         return None
+
+
+def production_smoketests_status(ci_jobs):
+    """Read total number of remembered builds and failed builds as well."""
+    job_url = ci_jobs.get_job_url("production", "smoketests")
+    api_query = jenkins_api_query_build_statuses(job_url)
+    response = requests.get(api_query)
+    builds = response.json()["builds"]
+    total_builds = [b for b in builds if b["result"] is not None]
+    failed_builds = [b for b in builds if b["result"] == "SUCCESS"]
+    return len(total_builds), len(failed_builds)
 
 
 def main():
@@ -468,6 +484,9 @@ def main():
 
     ci_jobs = CIJobs()
     job_statuses = read_job_statuses(ci_jobs, ci_jobs_table_enabled, liveness_table_enabled)
+
+    results.smoke_tests_total_builds, results.smoke_tests_failures = \
+        production_smoketests_status(ci_jobs)
 
     for team in teams:
         results.issues_list_url[team] = config.get_list_of_issues_url(team)

--- a/dashboard/src/dashboard.py
+++ b/dashboard/src/dashboard.py
@@ -448,8 +448,8 @@ def production_smoketests_status(ci_jobs):
     response = requests.get(api_query)
     builds = response.json()["builds"]
     total_builds = [b for b in builds if b["result"] is not None]
-    failed_builds = [b for b in builds if b["result"] == "SUCCESS"]
-    return len(total_builds), len(failed_builds)
+    success_builds = [b for b in builds if b["result"] == "SUCCESS"]
+    return len(total_builds), len(success_builds)
 
 
 def main():
@@ -485,7 +485,7 @@ def main():
     ci_jobs = CIJobs()
     job_statuses = read_job_statuses(ci_jobs, ci_jobs_table_enabled, liveness_table_enabled)
 
-    results.smoke_tests_total_builds, results.smoke_tests_failures = \
+    results.smoke_tests_total_builds, results.smoke_tests_success_builds = \
         production_smoketests_status(ci_jobs)
 
     for team in teams:

--- a/dashboard/src/dashboard.py
+++ b/dashboard/src/dashboard.py
@@ -442,7 +442,7 @@ def read_job_statuses(ci_jobs, ci_jobs_table_enabled, liveness_table_enabled):
 
 
 def production_smoketests_status(ci_jobs):
-    """Read total number of remembered builds and failed builds as well."""
+    """Read total number of remembered builds and succeeded builds as well."""
     job_url = ci_jobs.get_job_url("production", "smoketests")
     api_query = jenkins_api_query_build_statuses(job_url)
     response = requests.get(api_query)

--- a/dashboard/src/results.py
+++ b/dashboard/src/results.py
@@ -27,7 +27,7 @@ class Results():
         self.sla = {}
         self.smoke_tests_results = {}
         self.smoke_tests_total_builds = 0
-        self.smoke_tests_failures = 0
+        self.smoke_tests_success_builds = 0
         self.generated_on = time.strftime('%Y-%m-%d %H:%M:%S')
         self.ci_jobs_links = defaultdict(dict)
         self.ci_jobs_statuses = defaultdict(dict)

--- a/dashboard/src/results.py
+++ b/dashboard/src/results.py
@@ -26,6 +26,8 @@ class Results():
         self.f = lambda number: '{0:.2f}'.format(number)  # function to format floating point number
         self.sla = {}
         self.smoke_tests_results = {}
+        self.smoke_tests_total_builds = 0
+        self.smoke_tests_failures = 0
         self.generated_on = time.strftime('%Y-%m-%d %H:%M:%S')
         self.ci_jobs_links = defaultdict(dict)
         self.ci_jobs_statuses = defaultdict(dict)

--- a/dashboard/template/dashboard.html
+++ b/dashboard/template/dashboard.html
@@ -25,7 +25,7 @@
                 <div class="panel panel-primary">
                     <div class="panel-heading">Services liveness and readiness</div>
                     <table class="table table-condensed table-hover table-bordered" rules="all">
-                        <tr><th>Environment</th><th>Core API</th><th>Jobs API</th><th>Auth.token<br />to core API</th><th>Auth.token<br />to jobs API</th><th>Smoketests</th></tr>
+                        <tr><th>Environment</th><th>Core API</th><th>Jobs API</th><th>Auth.token<br />to core API</th><th>Auth.token<br />to jobs API</th><th>Smoketests</th><th>Smoketests<br />history</th></tr>
                         <tr><td>Stage</td>
                             % if stage["core_api_available"]:
                                 <td class="boolean ok">&#x2713;</td>
@@ -54,10 +54,15 @@
                                 % else:
                                     <span class="ci_status boolean error">&times;</span>
                                 % endif
-                                    <a href='${smoke_tests_links["stage"]}'>link</a></td>
+                                <a href='${smoke_tests_links["stage"]}'>link</a>
+                                </td>
                             % else:
                                 <td class="boolean error">?</td>
                             % endif
+                            <td>
+                            &nbsp;
+                            <!-- we don't have smoketests CI builds for the stage -->
+                            </td>
                         </tr>
                         <tr><td>Production</td>
                             % if production["core_api_available"]:
@@ -87,10 +92,14 @@
                                 % else:
                                     <span class="ci_status boolean error">&times;</span>
                                 % endif
-                                    <a href='${smoke_tests_links["production"]}'>link</a></td>
+                                    <a href='${smoke_tests_links["production"]}'>link</a>
+                                </td>
                             % else:
                                 <td class="boolean error">?</td>
                             % endif
+                            <td style="width:3ex">
+                                <a href='${smoke_tests_links["production"]}'>${smoke_tests_failures}/${smoke_tests_total_builds}</a>
+                            </td>
                         </tr>
                     </table>
                 </div>

--- a/dashboard/template/dashboard.html
+++ b/dashboard/template/dashboard.html
@@ -98,7 +98,7 @@
                                 <td class="boolean error">?</td>
                             % endif
                             <td style="width:3ex">
-                                <a href='${smoke_tests_links["production"]}'>${smoke_tests_failures}/${smoke_tests_total_builds}</a>
+                                <a href='${smoke_tests_links["production"]}'>${smoke_tests_success_builds}/${smoke_tests_total_builds}</a>
                             </td>
                         </tr>
                     </table>


### PR DESCRIPTION
Original issue: https://github.com/openshiftio/openshift.io/issues/1794

Please look at: https://fabric8-analytics.github.io/dashboard/dashboard.html where the new column is displayed (top right corner)