### PR TITLE
Display code coverage report

### DIFF
--- a/dashboard/src/ci_jobs.py
+++ b/dashboard/src/ci_jobs.py
@@ -41,6 +41,15 @@ class CIJobs:
         except (configparser.NoSectionError, configparser.NoOptionError):
             return None
 
+    def get_console_output_url(self, repository_name):
+        """Return URL that can be used to fetch console output of the last build."""
+        try:
+            job_url = self.get_job_url(repository_name, "test_job")
+            if job_url is not None:
+                return urljoin(job_url + "/", "lastBuild/consoleText")
+        except (configparser.NoSectionError, configparser.NoOptionError):
+            return None
+
     @staticmethod
     def construct_job_url(url_prefix, url_suffix):
         """Construct the URL to job on CI from CI prefix and suffix with job name."""

--- a/dashboard/src/dashboard.py
+++ b/dashboard/src/dashboard.py
@@ -456,16 +456,16 @@ def read_unit_test_coverage(ci_jobs, jenkins_url, repository):
             unit_test_output = []
             for line in content:
                 line = line.strip()
-                if unit_test_output:
-                    unit_test_output.append(line)
                 # check where the test coverage begins
                 if line.startswith("Name  ") and line.endswith("Stmts   Miss  Cover   Missing"):
                     unit_test_output.append(line)
                 # check where the test coverage ends
-                if line.startswith("TOTAL                   "):
+                elif line.startswith("TOTAL                   "):
                     unit_test_output.append(line)
                     write_unit_test_coverage(unit_test_output, repository)
                     return parse_unit_test_statistic(line)
+                elif unit_test_output:
+                    unit_test_output.append(line)
     return None
 
 

--- a/dashboard/src/results.py
+++ b/dashboard/src/results.py
@@ -28,12 +28,15 @@ class Results():
         self.smoke_tests_results = {}
         self.smoke_tests_total_builds = 0
         self.smoke_tests_success_builds = 0
+        self.smoke_tests_links = None
+        self.smoke_tests_statuses = None
         self.generated_on = time.strftime('%Y-%m-%d %H:%M:%S')
         self.ci_jobs_links = defaultdict(dict)
         self.ci_jobs_statuses = defaultdict(dict)
         self.sprint = None
         self.teams = {}
         self.issues_list_url = {}
+        self.unit_test_coverage = {}
 
     def __repr__(self):
         """Return textual representation of all results."""
@@ -43,7 +46,8 @@ class Results():
                    "Smoke tests links: {smoke_tests_links}\n" + \
                    "Smoke tests statuses: {smoke_tests_statuses}\n" + \
                    "CI jobs links: {ci_jobs_links}\n" + \
-                   "CI jobs status: {ci_jobs_stats}\n"
+                   "CI jobs status: {ci_jobs_stats}\n" + \
+                   "Unit test coverage: {unit_test_coverage}\n"
         return template.format(stage=self.stage,
                                production=self.production,
                                rs=self.repo_statistics,
@@ -53,4 +57,5 @@ class Results():
                                smoke_tests_links=self.smoke_tests_links,
                                smoke_tests_statuses=self.smoke_tests_statuses,
                                ci_jobs_links=self.ci_jobs_links.__repr__(),
-                               ci_jobs_stats=self.ci_jobs_statuses.__repr__())
+                               ci_jobs_stats=self.ci_jobs_statuses.__repr__(),
+                               unit_test_coverage=self.unit_test_coverage)

--- a/dashboard/template/dashboard.html
+++ b/dashboard/template/dashboard.html
@@ -155,33 +155,46 @@
                 <div class="panel panel-primary">
                     <div class="panel-heading">Code quality</div>
                     <table class="table table-condensed table-hover table-bordered" rules="all">
-                        <tr><th>Repository</th><th colspan="2">Source files</th><th colspan="3">Linter results</th><th colspan="3">Pydocstyle results</th><th>Overall status</th><th>Remark</th></tr>
-                        <tr><th>&nbsp;</th><th>Files</th><th>Total lines</th><th>Pass</th><th>Fail</th><th>Pass %</th><th>Pass</th><th>Fail</th><th>Pass %</th><th>&nbsp;</th><th>&nbsp;</th></tr>
+                        <tr><th>Repository</th><th colspan="2">Source files</th><th colspan="3">Linter results</th><th colspan="3">Pydocstyle results</th><th colspan="3">Code coverage</th><th>Overall status</th><th>Remark</th></tr>
+                        <tr><th>&nbsp;</th><th>Files</th><th>Total lines</th><th>Pass</th><th>Fail</th><th>Pass %</th><th>Pass</th><th>Fail</th><th>Pass %</th><th>Stmts.</th><th>Missed</th><th>Covered</th><th>&nbsp;</th><th>&nbsp;</th></tr>
                     % for repository in repositories:
                         <tr>
                             <td style="width:36ex"><a href="${repo_prefix}${repository}">${repository}</a></td>
-                            <td class="numeric" style="width:8ex"><a href="repository_${repository}.html">${source_files[repository]["count"]}</a></td>
-                            <td class="numeric" style="width:8ex">${source_files[repository]["total_lines"]}</td>
-                            <td class="numeric ok" style="width:8ex">${repo_linter_checks[repository]["passed"]}</td>
-                            <td class="numeric error" style="width:8ex">${repo_linter_checks[repository]["failed"]}</td>
+                            <td class="numeric" style="width:7ex"><a href="repository_${repository}.html">${source_files[repository]["count"]}</a></td>
+                            <td class="numeric" style="width:7ex">${source_files[repository]["total_lines"]}</td>
+                            <td class="numeric ok" style="width:7ex">${repo_linter_checks[repository]["passed"]}</td>
+                            <td class="numeric error" style="width:7ex">${repo_linter_checks[repository]["failed"]}</td>
                             <td class="numeric" style="width:16ex">
                                 <div class='progress-bar ${repo_linter_checks[repository]["progress_bar_class"]} progress-bar-striped' style='width:${repo_linter_checks[repository]["progress_bar_width"]}%'>
                                 ${repo_linter_checks[repository]["passed%"]}%
                                 </div>
                             </td>
-                            <td class="numeric ok" style="width:8ex">${repo_docstyle_checks[repository]["passed"]}</td>
-                            <td class="numeric error" style="width:8ex">${repo_docstyle_checks[repository]["failed"]}</td>
+                            <td class="numeric ok" style="width:7ex">${repo_docstyle_checks[repository]["passed"]}</td>
+                            <td class="numeric error" style="width:7ex">${repo_docstyle_checks[repository]["failed"]}</td>
                             <td class="numeric" style="width:16ex">
                                 <div class='progress-bar ${repo_docstyle_checks[repository]["progress_bar_class"]} progress-bar-striped' style='width:${repo_docstyle_checks[repository]["progress_bar_width"]}%'>
                                 ${repo_docstyle_checks[repository]["passed%"]}%
                                 </div>
                             </td>
+                            % if unit_test_coverage[repository] is not None:
+                                <td class="numeric ok" style="width:7ex">${unit_test_coverage[repository]["statements"]}</td>
+                                <td class="numeric error" style="width:7ex">${unit_test_coverage[repository]["missed"]}</td>
+                                <td class="numeric" style="width:16ex">
+                                    <div class='progress-bar ${unit_test_coverage[repository]["progress_bar_class"]} progress-bar-striped' style='width:${unit_test_coverage[repository]["progress_bar_width"]}%'>
+                                    ${unit_test_coverage[repository]["coverage"]}%
+                                    </div>
+                                </td>
+                            % else:
+                                <td style="width:7ex">&nbsp;</td>
+                                <td style="width:7ex">&nbsp;</td>
+                                <td style="width:16ex">&nbsp;</td>
+                            % endif
                             % if overall_status[repository]:
                                 <td class="boolean ok">&#x2713;</td>
                             % else:
                                 <td class="boolean error">&times;</td>
                             % endif
-                            <td style="width:30ex">${remarks[repository]}</td>
+                            <td style="width:26ex">${remarks[repository]}</td>
                     % endfor
                     </table>
                 </div>


### PR DESCRIPTION
## New feature

Ability to display code coverage results on the dashboard:
https://fabric8-analytics.github.io/dashboard/dashboard.html

Please note that 'bar meters' are not displayed for repositories w/o any unit tests.