### PR TITLE
Blackduck analysis was removed

### DIFF
--- a/integration-tests/features/environment.py
+++ b/integration-tests/features/environment.py
@@ -541,17 +541,13 @@ def before_all(context):
         # 'static_analysis', 'binary_data', 'languages', 'crypto_algorithms'
     }
     # Analyses that are only executed for particular language ecosystems
-    context.ECOSYSTEM_DEPENDENT_ANALYSES = {
-        "maven": {'blackduck'},
-        "npm": {'blackduck'},
-    }
+    context.ECOSYSTEM_DEPENDENT_ANALYSES = dict()
     # Results that use a nonstandard format, so we don't check for the
     # standard "status", "summary", and "details" keys
     context.NONSTANDARD_ANALYSIS_FORMATS = set()
     # Analyses that are just plain unreliable and so need to be excluded from
     # consideration when determining whether or not an analysis is complete
     context.UNRELIABLE_ANALYSES = {
-        'blackduck',
         'github_details',  # if no github api token provided
         'security_issues'  # needs Snyk vulndb in S3
     }

--- a/integration-tests/features/server_api.feature
+++ b/integration-tests/features/server_api.feature
@@ -104,7 +104,6 @@ Feature: Server API
      Examples: schemas
          |schema|version|
          |binary_data|1-0-0|
-         |blackduck|1-0-0|
          |code_metrics|1-0-0|
          |crypto_algorithms|1-0-0|
          |dependency_snapshot|1-0-0|
@@ -180,7 +179,6 @@ Feature: Server API
      Examples: schemas
          |schema|version|
          |binary_data|1-0-0|
-         |blackduck|1-0-0|
          |code_metrics|1-0-0|
          |crypto_algorithms|1-0-0|
          |dependency_snapshot|1-0-0|
@@ -278,7 +276,6 @@ Feature: Server API
          |api|stack_analyses|2-2-0|
          |api|version_range_resolver|1-0-0|
          |component_analyses|binary_data|1-0-0|
-         |component_analyses|blackduck|1-0-0|
          |component_analyses|code_metrics|1-0-0|
          |component_analyses|crypto_algorithms|1-0-0|
          |component_analyses|dependency_snapshot|1-0-0|


### PR DESCRIPTION
in https://github.com/fabric8-analytics/fabric8-analytics-worker/commit/bd244453ce6f47c47927e3ecbfad12fc4e1c14b8

see failing https://ci.centos.org/job/devtools-f8a-master-deploy-e2e-test/812/consoleFull