### PR TITLE
Stack analysis PyPi ecosystem tests fix + fix for other tests

### DIFF
--- a/integration-tests/feature_list.txt
+++ b/integration-tests/feature_list.txt
@@ -4,7 +4,7 @@ features/server_api.feature
 ## temporary: features/jobs_api.feature
 ## temporary: features/jobs_debug_api.feature
 #features/ecosystems.feature
-features/component_search.feature
+# Not used in real production: features/component_search.feature
 features/components.feature
 features/stack_analyses.feature
 features/stack_analyses_pypi_ecosystem.feature
@@ -13,7 +13,7 @@ features/user_feedback.feature
 #features/versions.feature
 features/selfcheck.feature
 #features/regression_tests.feature
-features/user_tag.feature
+# Not used in real production: features/user_tag.feature
 ## temporary: features/gremlin.feature
 features/three_scale.feature
 #features/api_backbone.feature

--- a/integration-tests/features/stack_analyses_pypi_ecosystem.feature
+++ b/integration-tests/features/stack_analyses_pypi_ecosystem.feature
@@ -190,7 +190,7 @@ Feature: Thorough stack analysis v3 API tests
     # Licence and dependency counters checks
     When I look at recent stack analysis
     Then I should find the value requirements.txt under the path result/0/manifest_name in the JSON response
-     And I should find the value 6 under the path result/0/user_stack_info/total_licenses in the JSON response
+     And I should find the value 7 under the path result/0/user_stack_info/total_licenses in the JSON response
      And I should find the value 0 under the path result/0/user_stack_info/transitive_count in the JSON response
      And I should find the value 0 under the path result/0/user_stack_info/unknown_dependencies_count in the JSON response
      And I should find the value 11 under the path result/0/user_stack_info/analyzed_dependencies_count in the JSON response


### PR DESCRIPTION
@miteshvp it fix the issue caused by data migration. Unfortunately there are two other issues that cause the e2e to fail, so right now we are blocked by them.

Another two test features has been commented out, it's based on our agreement on cabal not to test things not used on production.