### PR TITLE
Reduce the time needed to stabilize threescale service

### DIFF
--- a/integration-tests/features/three_scale_component_analyses.feature
+++ b/integration-tests/features/three_scale_component_analyses.feature
@@ -10,7 +10,7 @@ Feature: Component Search API Through 3Scale Gateway
   Scenario: Check the component analyses functionality for existent npm dependency through 3scale gateway
     Given System is running
     Given Three scale preview service is running
-    When I wait 60 seconds
+    When I wait 5 seconds
     When I acquire the use_key for 3scale
     Then I should get the proper user_key
     When I start component analyses npm/sequence/2.2.0 with user_key


### PR DESCRIPTION
Previously we need to wait for the threescale service to breath (after it is started in devcluster or on local machine). There's no need to do it so aggressively on pre-prod and on new devcluster setups.