### PR TITLE
QA script use directories.txt

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -81,6 +81,8 @@ Use the following scripts to check if the code follows PEP 8 and PEP 257 coding 
 
 Ensure that you fix any warnings and errors reported by these scripts.
 
+List of directories containing source code, that needs to be checked, are stored in a file `directories.txt`
+
 == Code complexity measurement
 Use the following scripts to measure code complexity. These scripts can be run w/o any arguments:
 
@@ -99,6 +101,8 @@ Please note that due to Python's dynamic nature, static code analyzers are likel
 
 Because of this potential problems, only code detected with more than 90% of confidence is reported.
 
+List of directories containing source code, that needs to be checked, are stored in a file `directories.txt`
+
 == Common issues detection
 
 The script `detect-common-errors.sh` can be used to detect common errors in the repository. This script can be run w/o any arguments:
@@ -108,5 +112,7 @@ The script `detect-common-errors.sh` can be used to detect common errors in the 
 ----
 
 Please note that only semantical problems are reported.
+
+List of directories containing source code, that needs to be checked, are stored in a file `directories.txt`
 
 ////

--- a/check-docstyle.sh
+++ b/check-docstyle.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
-directories="integration-tests ui-tests perf-tests dashboard reproducers load-tests db-integrity-tests taas job-checker baf e2e_tests_bot vscode-visual-tests a2t tools"
+IFS=$'\n'
+
+# list of directories with sources to check
+directories=$(cat directories.txt)
+
 pass=0
 fail=0
 

--- a/detect-common-errors.sh
+++ b/detect-common-errors.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
-directories="integration-tests ui-tests perf-tests dashboard reproducers load-tests db-integrity-tests taas baf e2e_tests_bot vscode-visual-tests a2t tools"
+IFS=$'\n'
+
+# list of directories with sources to check
+directories=$(cat directories.txt)
+
 pass=0
 fail=0
 

--- a/detect-dead-code.sh
+++ b/detect-dead-code.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
-directories="integration-tests ui-tests perf-tests dashboard reproducers load-tests db-integrity-tests taas baf e2e_tests_bot vscode-visual-tests a2t tools"
+IFS=$'\n'
+
+# list of directories with sources to check
+directories=$(cat directories.txt)
+
 pass=0
 fail=0
 

--- a/directories.txt
+++ b/directories.txt
@@ -1,0 +1,14 @@
+integration-tests
+ui-tests
+perf-tests
+dashboard
+reproducers
+load-tests
+db-integrity-tests
+taas
+job-checker
+baf
+e2e_tests_bot
+vscode-visual-tests
+a2t
+tools

--- a/run-linter.sh
+++ b/run-linter.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
-directories="integration-tests ui-tests perf-tests dashboard reproducers load-tests db-integrity-tests taas job-checker baf e2e_tests_bot vscode-visual-tests a2t tools"
+IFS=$'\n'
+
+# list of directories with sources to check
+directories=$(cat directories.txt)
+
 pass=0
 fail=0
 


### PR DESCRIPTION
This PR implements the first task in:
https://jira.coreos.com/browse/APPAI-516

Make all QA-related tools more effective and easier to use by developers

1. All QA-related scripts needs to be made unified by using external list of directories to check
2. All QA-related scripts needs to be moved into separate subdirectory
3.QA Dashboard should be updated to use the new scripts (as #1)

JIRA issue for the 1st task:
https://jira.coreos.com/browse/APPAI-481

Currently, several QA-related scripts have the 'source-directories' included in the script body. It would be nice to use separate and central configuration file for this.
