### PR TITLE
Removing fixed SLO duration Checks

### DIFF
--- a/integration-tests/features/stack_analyses_smoke_tests_npm_ecosystem.feature
+++ b/integration-tests/features/stack_analyses_smoke_tests_npm_ecosystem.feature
@@ -25,7 +25,7 @@ Feature: Smoketests for stack analysis API tests for NPM ecosystem
 
     # SLA/SLO-related checks
     When I look at the stack analysis duration
-    Then I should see that the duration is less than 40 seconds
+    Then I should receive a valid JSON response
 
     # Timestamp checks
     When I look at recent stack analysis

--- a/integration-tests/features/stack_analyses_smoke_tests_pypi_ecosystem.feature
+++ b/integration-tests/features/stack_analyses_smoke_tests_pypi_ecosystem.feature
@@ -25,7 +25,7 @@ Feature: Smoketests for stack analysis API tests for PyPi ecosystem
 
     # SLA/SLO-related checks
     When I look at the stack analysis duration
-    Then I should see that the duration is less than 20 seconds
+    Then I should receive a valid JSON response
 
     # Timestamp checks
     When I look at recent stack analysis

--- a/integration-tests/features/stack_analysis_maven_direct_and_transitive.feature
+++ b/integration-tests/features/stack_analysis_maven_direct_and_transitive.feature
@@ -25,7 +25,7 @@ Feature: Smoketests for stack analysis API tests for Maven ecosystem
 
     # SLA/SLO-related checks
     When I look at the stack analysis duration
-    Then I should see that the duration is less than 30 seconds
+    Then I should receive a valid JSON response
 
     # Timestamp checks
     When I look at recent stack analysis

--- a/integration-tests/features/stack_analysis_npm_direct_and_transitive.feature
+++ b/integration-tests/features/stack_analysis_npm_direct_and_transitive.feature
@@ -25,7 +25,7 @@ Feature: Thorough stack analysis v3 API tests for Node ecosystem
 
     # SLA/SLO-related checks
     When I look at the stack analysis duration
-    Then I should see that the duration is less than 50 seconds
+    Then I should receive a valid JSON response
 
     # Timestamp checks
     When I look at recent stack analysis
@@ -77,7 +77,7 @@ Feature: Thorough stack analysis v3 API tests for Node ecosystem
 
     # SLA/SLO-related checks
     When I look at the stack analysis duration
-    Then I should see that the duration is less than 40 second
+    Then I should receive a valid JSON response
 
     # Timestamp checks
     When I look at recent stack analysis
@@ -129,7 +129,7 @@ Feature: Thorough stack analysis v3 API tests for Node ecosystem
 
     # SLA/SLO-related checks
     When I look at the stack analysis duration
-    Then I should see that the duration is less than 40 second
+    Then I should receive a valid JSON response
 
     # Timestamp checks
     When I look at recent stack analysis

--- a/integration-tests/features/stack_analysis_pypi_direct_and_transitive.feature
+++ b/integration-tests/features/stack_analysis_pypi_direct_and_transitive.feature
@@ -25,7 +25,7 @@ Feature: Smoketests for stack analysis API tests for PyPi ecosystem
 
     # SLA/SLO-related checks
     When I look at the stack analysis duration
-    Then I should see that the duration is less than 30 seconds
+    Then I should receive a valid JSON response
 
     # Timestamp checks
     When I look at recent stack analysis


### PR DESCRIPTION
# Description
Fixed SLO/ SLI duration checks are creating concerns for larger stacks.
Replacing checks with Json Validity checks only. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
