### PR TITLE
Add the fabric8-analytics-scaler repository to the QA Dashboard

### DIFF
--- a/dashboard/ci_jobs.ini
+++ b/dashboard/ci_jobs.ini
@@ -168,3 +168,7 @@ build_job=devtools-victimsdb-lib-build-master
 test_job=devtools-victimsdb-lib-fabric8-analytics
 pylint_job=devtools-victimsdb-lib-fabric8-analytics-pylint
 pydoc_job=devtools-victimsdb-lib-fabric8-analytics-pydoc
+
+[fabric8-analytics-scaler]
+build_job=devtools-fabric8-analytics-scaler-f8a-build-master
+test_job=devtools-fabric8-analytics-scaler-fabric8-analytics

--- a/dashboard/config.ini
+++ b/dashboard/config.ini
@@ -14,7 +14,7 @@ number=150
 plan_issue=2775
 
 [repositories]
-repolist=fabric8-analytics-common,fabric8-analytics-server,fabric8-analytics-worker,fabric8-analytics-jobs,fabric8-analytics-tagger,fabric8-analytics-stack-analysis,fabric8-analytics-license-analysis,fabric8-analytics-data-model,fabric8-analytics-recommender,fabric8-analytics-api-gateway,fabric8-analytics-nvd-toolkit,fabric8-analytics-auth,fabric8-gemini-server,fabric8-analytics-version-comparator,fabric8-analytics-ingestion,fabric8-analytics-npm-insights,fabric8-analytics-notification-scheduler,fabric8-analytics-utils,fabric8-analytics-github-refresh-cronjob,fabric8-analytics-github-events-monitor,fabric8-analytics-release-monitor,f8a-server-backbone,fabric8-analytics-rudra,f8a-hpf-insights,f8a-golang-insights,f8a-pypi-insights,f8a-stacks-report,cvejob,victimsdb-lib,fabric8-analytics-jenkins-plugin
+repolist=fabric8-analytics-common,fabric8-analytics-server,fabric8-analytics-worker,fabric8-analytics-jobs,fabric8-analytics-tagger,fabric8-analytics-stack-analysis,fabric8-analytics-license-analysis,fabric8-analytics-data-model,fabric8-analytics-recommender,fabric8-analytics-api-gateway,fabric8-analytics-nvd-toolkit,fabric8-analytics-auth,fabric8-gemini-server,fabric8-analytics-version-comparator,fabric8-analytics-ingestion,fabric8-analytics-npm-insights,fabric8-analytics-notification-scheduler,fabric8-analytics-utils,fabric8-analytics-github-refresh-cronjob,fabric8-analytics-github-events-monitor,fabric8-analytics-release-monitor,f8a-server-backbone,fabric8-analytics-rudra,fabric8-analytics-scaler,f8a-hpf-insights,f8a-golang-insights,f8a-pypi-insights,f8a-stacks-report,cvejob,victimsdb-lib,fabric8-analytics-jenkins-plugin
 
 [code_coverage_threshold]
 overall=90%
@@ -39,6 +39,7 @@ fabric8-analytics-release-monitor=90%
 fabric8-analytics-github-refresh-cronjob=90%
 fabric8-analytics-github-events-monitor=90%
 fabric8-analytics-rudra=90%
+fabric8-analytics-scaler=90%
 f8a-server-backbone=90%
 f8a-hpf-insights=90%
 f8a-pypi-insights=90%


### PR DESCRIPTION
# Description

Fabric8-analytics-scaler repository has been added to the QA Dashboard

Fixes #761

## Type of change

- [x] New feature (non-breaking change which adds functionality)
