### PR TITLE
remove endpoints not accessed by IDE extension from the hourly prod E2E

### DIFF
--- a/integration-tests/features/components.feature
+++ b/integration-tests/features/components.feature
@@ -14,7 +14,7 @@ Feature: Components API V1
       And I search for component sequence without authorization token
      Then I should get 401 status code
 
-  @requires_authorization_token @production
+  @requires_authorization_token
   Scenario: Check the component search API entry point
     Given System is running
       And Component search service is running
@@ -23,7 +23,7 @@ Feature: Components API V1
      When I search for component foobar with authorization token
      Then I should get 200 status code
 
-  @requires_authorization_token @production
+  @requires_authorization_token
   Scenario: Check the component search API entry point for the component that does not exist
     Given System is running
       And Component search service is running
@@ -54,7 +54,7 @@ Feature: Components API V1
      When I access /api/v1/component-analyses/
      Then I should get 404 status code
 
-  @requires_authorization_token @production
+  @requires_authorization_token
   Scenario: Check if search for packages handle empty results
     Given System is running
       And Component search service is running

--- a/integration-tests/features/server_api.feature
+++ b/integration-tests/features/server_api.feature
@@ -126,7 +126,6 @@ Feature: Server API
      Then I should get 200 status code
 
 
-  @production
   Scenario Outline: Check that the HTTP method is check properly on server side for the /api/v1/system/version
     Given System is running
      When I access /api/v1/system/version/

--- a/integration-tests/features/user_intent.feature
+++ b/integration-tests/features/user_intent.feature
@@ -1,6 +1,5 @@
 Feature: Tests for user intent API version 1.0
 
-  @production
   Scenario Outline: Check the existence of REST API endpoint for user-intent
     Given System is running
     When I access /api/v1/
@@ -14,21 +13,18 @@ Feature: Tests for user intent API version 1.0
          |/api/v1/user-intent/<user>/<ecosystem>|
 
 
-  @production
   Scenario: Check that the API entry point for user intent requires authorization token
     Given System is running
      When I access /api/v1/user-intent
      Then I should not get 200 status code
 
 
-  @production
   Scenario: Check the HTTP POST call for user intent endpoint - the authorization token should be required
     Given System is running
      When I access the /api/v1/user-intent endpoint using the HTTP POST method
      Then I should get 401 status code
 
 
-  @production
   Scenario: Check that the API entry point for user checks 'user' and 'ecosystem' arguments
     Given System is running
      When I acquire the authorization token
@@ -39,7 +35,6 @@ Feature: Tests for user intent API version 1.0
       And I should receive JSON response containing the error key
 
 
-  @production
   Scenario: Check that the API entry point for user checks 'user' and 'ecosystem' arguments
     Given System is running
      When I acquire the authorization token
@@ -50,7 +45,6 @@ Feature: Tests for user intent API version 1.0
       And I should receive JSON response containing the error key
 
 
-  @production
   Scenario: Check that the API entry point for user checks 'user' and 'ecosystem' arguments
     Given System is running
      When I acquire the authorization token
@@ -89,7 +83,6 @@ Feature: Tests for user intent API version 1.0
      | DELETE | 405 |
 
 
-  @production
   Scenario: Check the HTTP POST call for user intent endpoint - proper authorization token, but no payload
     Given System is running
      When I acquire the authorization token
@@ -101,7 +94,6 @@ Feature: Tests for user intent API version 1.0
       And I should receive JSON response with the error key set to Expected JSON request
 
 
-  @production
   Scenario: Check the HTTP POST call for user intent endpoint - proper authorization token and empty payload
     Given System is running
      When I acquire the authorization token
@@ -113,7 +105,6 @@ Feature: Tests for user intent API version 1.0
       And I should receive JSON response with the error key set to Expected JSON request
 
 
-  @production
   Scenario: Check the HTTP POST call for user intent endpoint - proper authorization token and incorrect payload
     Given System is running
      When I acquire the authorization token
@@ -125,7 +116,6 @@ Feature: Tests for user intent API version 1.0
       And I should receive JSON response with the error key set to Expected ecosystem in the request
 
 
-  @production
   Scenario: Check the HTTP POST call for user intent endpoint - proper authorization token and manual tagging in JSON
     Given System is running
      When I acquire the authorization token
@@ -137,7 +127,6 @@ Feature: Tests for user intent API version 1.0
       And I should receive JSON response with the error key set to Expected user name in the request
 
 
-  @production
   Scenario: Check the HTTP POST call for user intent endpoint - proper authorization token and manual tagging + user in JSON
     Given System is running
      When I acquire the authorization token
@@ -149,7 +138,6 @@ Feature: Tests for user intent API version 1.0
       And I should receive JSON response with the error key set to Expected tags in the request
 
 
-  @production
   Scenario: Check the HTTP POST call for user intent endpoint - proper authorization token and ecosystem in JSON
     Given System is running
      When I acquire the authorization token


### PR DESCRIPTION
# Description
Remove all the feature tests from hourly prod E2E tests that are not available via IDE extensions.
