### PR TITLE
Increase the stack analysis timeout for npm direct and transitive deps to 120 secs

### DIFF
--- a/integration-tests/features/stack_analysis_npm_direct_and_transitive.feature
+++ b/integration-tests/features/stack_analysis_npm_direct_and_transitive.feature
@@ -129,7 +129,7 @@ Feature: Thorough stack analysis v3 API tests for Node ecosystem
 
     # SLA/SLO-related checks
     When I look at the stack analysis duration
-    Then I should see that the duration is less than 40 second
+    Then I should see that the duration is less than 120 second
 
     # Timestamp checks
     When I look at recent stack analysis

--- a/integration-tests/runtest.sh
+++ b/integration-tests/runtest.sh
@@ -13,5 +13,4 @@ function prepare_venv() {
 
 
 
-
 PYTHONDONTWRITEBYTECODE=1 python3.4 `which behave` --tags=-skip --tags=-data-sanity -D dump_errors=true @feature_list.txt $@

--- a/integration-tests/runtest.sh
+++ b/integration-tests/runtest.sh
@@ -12,4 +12,6 @@ function prepare_venv() {
 [ "$NOVENV" == "1" ] || prepare_venv || exit 1
 
 
+
+
 PYTHONDONTWRITEBYTECODE=1 python3.4 `which behave` --tags=-skip --tags=-data-sanity -D dump_errors=true @feature_list.txt $@


### PR DESCRIPTION
# Description

I have Increased the duration from 40 to 120 secs for npm 150 direct and 1170 transitive dependencies

Fixes # (issue)
increase the stack analysis timeout to 120 sec
## Type of change

Please delete options that are not relevant.

- [- ] Bug fix (non-breaking change which fixes an issue)


