### PR TITLE
Migrated v1 component analysis tests to use 3scale auth 

### DIFF
--- a/integration-tests/features/component_analysis.feature
+++ b/integration-tests/features/component_analysis.feature
@@ -1,12 +1,14 @@
 Feature: Unknown licenses
 
-
+  
   Scenario Outline: Check the component analysis REST API endpoint for components without recommendations
     Given System is running
-     When I acquire the authorization token
-     Then I should get the proper authorization token
+    Given Three scale preview service is running
+    
+    When I acquire the use_key for 3scale
+    Then I should get the proper user_key
 
-     When I read <ecosystem>/<package>/<version> component analysis with authorization token
+     When I start component analyses <ecosystem>/<package>/<version> with user_key
      Then I should get 200 status code
       And I should receive a valid JSON response
       And I should receive JSON response containing the result key
@@ -20,7 +22,7 @@ Feature: Unknown licenses
      | npm | sequence | 3.0.0 |
      | npm | aargh | 1.1.0 |
      | npm | arrays | 0.1.1 |
-     | npm | jquery | 3.5.1 |
+     | npm | jquery | 3.5.0 |
      | npm | mocha | 6.1.4 |
      | npm | underscore | 1.9.1 |
      | npm | lodash | 4.17.15 |
@@ -96,33 +98,37 @@ Feature: Unknown licenses
      | pypi | pytest | 3.2.1 |
      | pypi | pytest | 3.2.2 |
 
-
+  
   Scenario: Check the component analysis REST API endpoint for unknown ecosystem
     Given System is running
-     When I acquire the authorization token
-     Then I should get the proper authorization token
+    Given Three scale preview service is running
+    
+    When I acquire the use_key for 3scale
+    Then I should get the proper user_key
 
-     When I start analysis for component really_unknown_ecosystem/foobar/1.0.0 with authorization token
+     When I start component analyses really_unknown_ecosystem/foobar/1.0.0 with user_key
      Then I should get 400 status code
       And I should receive a valid JSON response
 
-
+  
   Scenario: Check the component analysis REST API endpoint for unknown component in NPM ecosystem
     Given System is running
-     When I acquire the authorization token
-     Then I should get the proper authorization token
+    Given Three scale preview service is running
+   
+    When I acquire the use_key for 3scale
+    Then I should get the proper user_key
 
-     When I start analysis for component npm/really_unknown_component/1.0.0 with authorization token
+     When I start component analyses npm/really_unknown_component/1.0.0 with user_key
      Then I should get 202 status code
       And I should receive a valid JSON response
-
-
+  
   Scenario: Check the component analysis REST API endpoint for unknown component in PyPi ecosystem
     Given System is running
-     When I acquire the authorization token
-     Then I should get the proper authorization token
-
-     When I start analysis for component pypi/really_unknown_component/1.0.0 with authorization token
+    Given Three scale preview service is running
+  
+    When I acquire the use_key for 3scale
+    Then I should get the proper user_key
+     When I start component analyses pypi/really_unknown_component/1.0.0 with user_key
      Then I should get 202 status code
       And I should receive a valid JSON response
 
@@ -141,10 +147,12 @@ Feature: Unknown licenses
   @data-sanity
   Scenario Outline: Check the component analysis REST API endpoint for components with recommendation and one CVE
     Given System is running
-     When I acquire the authorization token
-     Then I should get the proper authorization token
+    Given Three scale preview service is running
+  
+    When I acquire the use_key for 3scale
+    Then I should get the proper user_key
 
-     When I read <ecosystem>/<package>/<version> component analysis with authorization token
+     When I start component analyses <ecosystem>/<package>/<version> with user_key
      Then I should get 200 status code
       And I should receive a valid JSON response
       And I should receive JSON response containing the result key
@@ -155,12 +163,12 @@ Feature: Unknown licenses
 
      Examples: EPV
      | ecosystem  | package             | version   | recommended-version | cve              | score |
-     | npm        | nuxt                | 2.0.0     | 2.8.1              | CVE-2019-13506   | 4.3   |
-     | npm        | nuxt                | 2.1.0     | 2.8.1              | CVE-2019-13506   | 4.3   |
-     | npm        | nuxt                | 2.3.0     | 2.8.1              | CVE-2019-13506   | 4.3   |
-     | npm        | nuxt                | 2.4.0     | 2.8.1              | CVE-2019-13506   | 4.3   |
-     | npm        | nuxt                | 2.5.0     | 2.8.1              | CVE-2019-13506   | 4.3   |
-     | npm        | nuxt                | 2.6.0     | 2.8.1              | CVE-2019-13506   | 4.3   |
+     | npm        | nuxt                | 2.0.0     | 2.12.2              | CVE-2019-13506   | 4.3   |
+     | npm        | nuxt                | 2.1.0     | 2.12.2              | CVE-2019-13506   | 4.3   |
+     | npm        | nuxt                | 2.3.0     | 2.12.2              | CVE-2019-13506   | 4.3   |
+     | npm        | nuxt                | 2.4.0     | 2.12.2              | CVE-2019-13506   | 4.3   |
+     | npm        | nuxt                | 2.5.0     | 2.12.2              | CVE-2019-13506   | 4.3   |
+     | npm        | nuxt                | 2.6.0     | 2.12.2              | CVE-2019-13506   | 4.3   |
      | maven      | io.vertx:vertx-core | 3.5.3     | 4.0.0-milestone4               | CVE-2018-12541   | 5.0   |
      | maven      | io.vertx:vertx-core | 3.5.3.CR1 | 4.0.0-milestone4               | CVE-2018-12541   | 5.0   |
      | maven      | io.vertx:vertx-core | 3.5.2     | 4.0.0-milestone4               | CVE-2018-12541   | 5.0   |
@@ -170,14 +178,22 @@ Feature: Unknown licenses
      | pypi       | flask               | 0.12      | 1.1.2               | CVE-2018-1000656 | 5.0   |
      | pypi       | flask               | 0.12.1    | 1.1.2               | CVE-2018-1000656 | 5.0   |
      | pypi       | flask               | 0.12.2    | 1.1.2               | CVE-2018-1000656 | 5.0   |
-     | pypi       | numpy               | 1.16.0    | 1.18.4              | CVE-2019-6446    | 7.5   |
-     | pypi       | numpy               | 1.15.4    | 1.18.4              | CVE-2019-6446    | 7.5   |
-     | pypi       | numpy               | 1.15.3    | 1.18.4              | CVE-2019-6446    | 7.5   |
-     | pypi       | numpy               | 1.15.2    | 1.18.4              | CVE-2019-6446    | 7.5   |
-     | pypi       | numpy               | 1.15.1    | 1.18.4              | CVE-2019-6446    | 7.5   |
+     | pypi       | numpy               | 1.16.0    | 1.18.5              | CVE-2019-6446    | 7.5   |
+     | pypi       | numpy               | 1.15.4    | 1.18.5              | CVE-2019-6446    | 7.5   |
+     | pypi       | numpy               | 1.15.3    | 1.18.5              | CVE-2019-6446    | 7.5   |
+     | pypi       | numpy               | 1.15.2    | 1.18.5              | CVE-2019-6446    | 7.5   |
+     | pypi       | numpy               | 1.15.1    | 1.18.5              | CVE-2019-6446    | 7.5   |
      | pypi       | requests            | 2.19.1    | 2.23.0              | CVE-2018-18074   | 5.0   |
      | pypi       | requests            | 2.19.0    | 2.23.0              | CVE-2018-18074   | 5.0   |
      | pypi       | requests            | 2.18.4    | 2.23.0              | CVE-2018-18074   | 5.0   |
      | pypi       | requests            | 2.18.3    | 2.23.0              | CVE-2018-18074   | 5.0   |
      | pypi       | requests            | 2.18.2    | 2.23.0              | CVE-2018-18074   | 5.0   |
      | pypi       | requests            | 2.17.3    | 2.23.0              | CVE-2018-18074   | 5.0   |
+
+
+
+
+
+
+
+

--- a/integration-tests/features/component_analysis_smoke_tests.feature
+++ b/integration-tests/features/component_analysis_smoke_tests.feature
@@ -3,10 +3,12 @@ Feature: Smoke tests for the component analysis REST API
 
   Scenario Outline: Check the component analysis REST API endpoint for selected components with and without recommendations
     Given System is running
-     When I acquire the authorization token
-     Then I should get the proper authorization token
+    Given Three scale preview service is running
+    When I wait 1 seconds
+    When I acquire the use_key for 3scale
+    Then I should get the proper user_key
 
-     When I read <ecosystem>/<package>/<version> component analysis with authorization token
+     When I start component analyses <ecosystem>/<package>/<version> with user_key
      Then I should get 200 status code
       And I should receive a valid JSON response
 

--- a/integration-tests/features/component_analysis_smoke_tests_100_maven_components.feature
+++ b/integration-tests/features/component_analysis_smoke_tests_100_maven_components.feature
@@ -2,11 +2,13 @@ Feature: Smoke tests for the component analysis REST API
 
 
   Scenario Outline: Check the component analysis REST API endpoint for 100 most popular PyPi components
-    Given System is running
-     When I acquire the authorization token
-     Then I should get the proper authorization token
+   Given System is running
+    Given Three scale preview service is running
+    When I wait 2 seconds
+    When I acquire the use_key for 3scale
+    Then I should get the proper user_key
 
-     When I read <ecosystem>/<package>/<version> component analysis with authorization token
+     When I start component analyses <ecosystem>/<package>/<version> with user_key
      Then I should get 200 status code
       And I should receive a valid JSON response
 

--- a/integration-tests/features/component_analysis_smoke_tests_100_npm_components.feature
+++ b/integration-tests/features/component_analysis_smoke_tests_100_npm_components.feature
@@ -1,12 +1,14 @@
-Feature: Smoke tests for the component analysis REST API
+ Feature: Smoke tests for the component analysis REST API
 
 
   Scenario Outline: Check the component analysis REST API endpoint for 100 most popular NPM components
     Given System is running
-     When I acquire the authorization token
-     Then I should get the proper authorization token
+    Given Three scale preview service is running
+    When I wait 2 seconds
+    When I acquire the use_key for 3scale
+    Then I should get the proper user_key
 
-     When I read <ecosystem>/<package>/<version> component analysis with authorization token
+     When I start component analyses <ecosystem>/<package>/<version> with user_key
      Then I should get 200 status code
       And I should receive a valid JSON response
 

--- a/integration-tests/features/component_analysis_smoke_tests_100_pypi_components.feature
+++ b/integration-tests/features/component_analysis_smoke_tests_100_pypi_components.feature
@@ -3,10 +3,12 @@ Feature: Smoke tests for the component analysis REST API
 
   Scenario Outline: Check the component analysis REST API endpoint for 100 most popular PyPi components
     Given System is running
-     When I acquire the authorization token
-     Then I should get the proper authorization token
+    Given Three scale preview service is running
+    When I wait 2 seconds
+    When I acquire the use_key for 3scale
+    Then I should get the proper user_key
 
-     When I read <ecosystem>/<package>/<version> component analysis with authorization token
+     When I start component analyses <ecosystem>/<package>/<version> with user_key
      Then I should get 200 status code
       And I should receive a valid JSON response
 

--- a/integration-tests/features/component_analysis_v2.feature
+++ b/integration-tests/features/component_analysis_v2.feature
@@ -26,19 +26,19 @@ Feature: Component analysis v2 API
      | npm        | marked                            | 0.3.5     | 1.1.0               | SNYK-JS-MARKED-10377                 | 7.5    |
      | npm        | st                                | 0.2.4     | 2.0.0               | SNYK-JS-ST-10820                     | 4.3    |
      | npm        | npmconf                           | 0.0.24    | 2.1.3               | SNYK-JS-NPMCONF-12143                | 7.4    |
-     | npm        | moment                            | 2.15.1    | 2.25.3              | SNYK-JS-MOMENT-10841                 | 3.7    |
-     | npm        | mongoose                          | 4.2.4     | 5.9.15              | SNYK-JS-MONGOOSE-10081               | 5.1    |
+     | npm        | moment                            | 2.15.1    | 2.26.0              | SNYK-JS-MOMENT-10841                 | 3.7    |
+     | npm        | mongoose                          | 4.2.4     | 5.9.18              | SNYK-JS-MONGOOSE-10081               | 5.1    |
      | maven      | io.vertx:vertx-core               | 3.5.3     | 4.0.0-milestone4    | SNYK-JAVA-IOVERTX-72443              | 6.5    |
      | maven      | org.webjars.bower:jquery          | 3.4.1     | 3.5.1               | SNYK-JAVA-ORGWEBJARSBOWER-567881     | 6.5    |
      | maven      | org.webjars:bootstrap-select      | 1.7.3     | 1.13.15             | SNYK-JAVA-ORGWEBJARS-479517          | 7.0    |
      | maven      | org.apache.camel:camel-rabbitmq   | 2.22.0    | 3.3.0               | SNYK-JAVA-ORGAPACHECAMEL-569123      | 6.5    | 
-     | maven      | org.apache.tomcat:tomcat-catalina | 7.0.0     | 10.0.0-M5           | SNYK-JAVA-ORGAPACHETOMCAT-32110      | 6.5    | 
+     | maven      | org.apache.tomcat:tomcat-catalina | 7.0.0     | 10.0.0-M6           | SNYK-JAVA-ORGAPACHETOMCAT-32110      | 6.5    | 
      | maven      | org.webjars.npm:openpgp           | 1.4.1     | 4.7.1               | SNYK-JAVA-ORGWEBJARSNPM-480073       | 7.0    |
      | pypi       | flask                             | 0.12      | 1.1.2               | SNYK-PYTHON-FLASK-42185              | 7.5    |
      | pypi       | fastapi                           | 0.36.0    | 0.55.1              | SNYK-PYTHON-FASTAPI-569038           | 5.3    |
      | pypi       | sceptre                           | 2.2.1     | 2.3.0               | SNYK-PYTHON-SCEPTRE-569070           | 6.5    |
      | pypi       | syft                              | 0.2.0a1   | 0.2.5               | SNYK-PYTHON-SYFT-568873              | 5.9    |
-     | pypi       | numpy                             | 1.15.4    | 1.18.4              | SNYK-PYTHON-NUMPY-73513              | 9.8    |
+     | pypi       | numpy                             | 1.15.4    | 1.18.5              | SNYK-PYTHON-NUMPY-73513              | 9.8    |
     
  
   

--- a/integration-tests/features/components.feature
+++ b/integration-tests/features/components.feature
@@ -30,23 +30,29 @@ Feature: Components API V1
 
   Scenario: Check if component analysis is accessible via API
     Given System is running
-     When I acquire the authorization token
-     Then I should get the proper authorization token
-     When I read npm/sequence/2.2.0 component analysis using authorization token
+    Given Three scale preview service is running
+    When I wait 1 seconds
+    When I acquire the use_key for 3scale
+    Then I should get the proper user_key
+     When I start component analyses npm/sequence/2.2.0 with user_key
      Then I should get 200 status code
 
   Scenario: Check if component analysis returns error code for unknown ecosystem
     Given System is running
-     When I acquire the authorization token
-     Then I should get the proper authorization token
-     When I read foobar/sequence/2.2.0 component analysis using authorization token
+    Given Three scale preview service is running
+    When I wait 1 seconds
+    When I acquire the use_key for 3scale
+    Then I should get the proper user_key
+     When I start component analyses foobar/sequence/2.2.0 with user_key
      Then I should not get 200 status code
 
   Scenario: Check if component analysis returns error code for unknown ecosystem
     Given System is running
-     When I acquire the authorization token
-     Then I should get the proper authorization token
-     When I read XYZZY/sequence/2.2.0 component analysis using authorization token
+    Given Three scale preview service is running
+    When I wait 1 seconds
+    When I acquire the use_key for 3scale
+    Then I should get the proper user_key
+     When I start component analyses XYZZY/sequence/2.2.0 with user_key
      Then I should not get 200 status code
 
   @production

--- a/integration-tests/features/steps/three_scale_preview.py
+++ b/integration-tests/features/steps/three_scale_preview.py
@@ -24,6 +24,8 @@ def threescale_preview_endpoint_url(context, endpoint, epv=[]):
 
 def perform_component_analysis(context, ecosystem, package, version, use_user_key, rate):
     """Call API endpoint to analysis for component."""
+    context.duration = None
+    start_time = time.time()
     url = threescale_preview_endpoint_url(
         context, 'component-analyses', [ecosystem, package, version])
     if use_user_key:
@@ -35,6 +37,8 @@ def perform_component_analysis(context, ecosystem, package, version, use_user_ke
                 break
     else:
         context.response = requests.get(url)
+    end_time = time.time()
+    context.duration = end_time - start_time
 
 
 def send_manifest_to_stack_analyses(context, manifest, name, endpoint, user_key, rate, origin,

--- a/integration-tests/requirements.txt
+++ b/integration-tests/requirements.txt
@@ -26,3 +26,4 @@ semantic_version==2.6.0
 six==1.10.0               # via behave, docker-py, docker-pycreds, parse-type, python-dateutil, websocket-client
 voluptuous==0.11.1
 websocket-client==0.37.0  # via docker-py
+requests-futures==1.0.0


### PR DESCRIPTION
# Description

Migrated v1 component analysis tests to 3scale auth and fixed CA v2 429 code with future requests 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
